### PR TITLE
Depend on aiotboto3 for dev

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiobotocore==2.1.0
+aioboto3==9.3.1
 aiofiles==0.8.0
 base58==2.1.1
 fastapi==0.79.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,3 @@
-aioboto3==9.3.1
 fsspec==2021.10.1
 pytest==6.2.5
 pytest-asyncio==0.19.0


### PR DESCRIPTION
- Depend on aioboto3 instead of aiobotocore for development, to avoid requirements conflicts when bumping either aioboto3 or aiobotocore.
- aioboto3 pins aiobotocore to a specific version so aiobotocore will be pinned anyway.