### PR TITLE
Pin fastapi to 0.104.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ DESCRIPTION = (
 
 REQUIREMENTS = [
     "aiofiles",
-    "fastapi>=0.70.0",
+    "fastapi==0.104.1",
     "imjoy-rpc>=0.5.44",
     "msgpack>=1.0.2",
     "numpy",


### PR DESCRIPTION
Following the version in requirements.txt.

pip freeze shows that 0.108.0 is installed, which results in the error:

```py
Traceback (most recent call last):
  File "lib/python3.11/site-packages/hypha/asgi.py", line 66, in __call__
    result = await func(scope)
             ^^^^^^^^^^^^^^^^^
Exception: can not serialize 'type' object
```

when using the login service.