### PR TITLE
Close the window on logout

### DIFF
--- a/hypha/templates/login_template.html
+++ b/hypha/templates/login_template.html
@@ -205,6 +205,7 @@
             window.logout = async ()=>{
                 const href = window.location.href;
                 await auth0.logout({ returnTo: href});         
+                window.close()
             }
     
             window.login = async () => {


### PR DESCRIPTION
Without this, the window remain open with page content only `{"name":"Hypha","version":"0.15.33"}` at the url
https://chat.bioimage.io/.

![image](https://github.com/amun-ai/hypha/assets/25432/c667d296-3d55-4fef-9fb7-aa9a7d9e12ab)
