### PR TITLE
Quick n dirty fix for permissions issues on k8s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /home
 RUN mkdir /home/bin && \
     cd /home/bin && wget https://dl.min.io/server/minio/release/linux-amd64/minio && \
     wget https://dl.min.io/client/mc/release/linux-amd64/mc && \
-    chmod -R 777 /home/bin
+    chmod -R 777 /home
 RUN mkdir /.mc && \
     chmod -R 777 /.mc
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
@oeway,

On k8s the "standard" permissions now seem to be 
```

  securityContext:
  enabled: true
  seLinuxOptions: null
  runAsUser: 1001
  runAsNonRoot: true
  privileged: false
  readOnlyRootFilesystem: false
  allowPrivilegeEscalation: false
  capabilities:
    drop: ["ALL"]
  seccompProfile:
    type: "RuntimeDefault"
  
```
  
  Which, however if you run the pod like this hypha then we get permissions issues . 
  
  Long term solution is to use something like `FROM:micromamba` which sets permissions properly
  
  