### PR TITLE
Use server id and clean up server records during startup

### DIFF
--- a/.github/workflows/test-helm-chart.yml
+++ b/.github/workflows/test-helm-chart.yml
@@ -37,17 +37,9 @@ jobs:
       run: |
         cd helm-charts
         helm package hypha-server
-        helm repo index . --url https://amun-ai.github.io/hypha/helm-charts
 
-    - name: Publish to gh-pages
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./helm-charts
-        publish_branch: gh-pages
-    
-    - name: Install Hypha Helm chart
-      run: helm install hypha-server hypha-server --namespace=hypha
+    - name: Install Hypha Helm chart from packaged .tgz
+      run: helm install hypha-server ./helm-charts/hypha-server-*.tgz --namespace=hypha
 
     - name: Uninstall Hypha Helm chart
       run: helm uninstall hypha-server --namespace=hypha

--- a/.github/workflows/test-helm-chart.yml
+++ b/.github/workflows/test-helm-chart.yml
@@ -48,7 +48,7 @@ jobs:
         helm install hypha-server ./dist/hypha-server-*.tgz --namespace=hypha
 
     - name: Uninstall Hypha Helm chart
-      run: 
+      run: |
         helm uninstall hypha-server --namespace=hypha
         helm uninstall redis --namespace=hypha
 

--- a/.github/workflows/test-helm-chart.yml
+++ b/.github/workflows/test-helm-chart.yml
@@ -37,12 +37,29 @@ jobs:
       run: |
         cd helm-charts
         helm package hypha-server
+        mkdir -p ../dist
+        mv hypha-server-*.tgz ../dist
+        helm package redis
+        mv redis-*.tgz ../dist
 
     - name: Install Hypha Helm chart from packaged .tgz
-      run: helm install hypha-server ./helm-charts/hypha-server-*.tgz --namespace=hypha
+      run: |
+        helm install redis ./helm-charts/redis-*.tgz --namespace=hypha
+        helm install hypha-server ./helm-charts/hypha-server-*.tgz --namespace=hypha
 
     - name: Uninstall Hypha Helm chart
-      run: helm uninstall hypha-server --namespace=hypha
+      run: 
+        helm uninstall hypha-server --namespace=hypha
+        helm uninstall redis --namespace=hypha
 
     - name: Delete namespace
       run: kubectl delete namespace hypha
+
+    - name: Upload to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./dist
+        publish_branch: gh-pages
+        keep_files: true

--- a/.github/workflows/test-helm-chart.yml
+++ b/.github/workflows/test-helm-chart.yml
@@ -44,8 +44,8 @@ jobs:
 
     - name: Install Hypha Helm chart from packaged .tgz
       run: |
-        helm install redis ./helm-charts/redis-*.tgz --namespace=hypha
-        helm install hypha-server ./helm-charts/hypha-server-*.tgz --namespace=hypha
+        helm install redis ./dist/redis-*.tgz --namespace=hypha
+        helm install hypha-server ./dist/hypha-server-*.tgz --namespace=hypha
 
     - name: Uninstall Hypha Helm chart
       run: 

--- a/.github/workflows/test-helm-chart.yml
+++ b/.github/workflows/test-helm-chart.yml
@@ -45,6 +45,9 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./helm-charts
         publish_branch: gh-pages
+    
+    - name: Install Hypha Helm chart
+      run: helm install hypha-server hypha-server --namespace=hypha
 
     - name: Uninstall Hypha Helm chart
       run: helm uninstall hypha-server --namespace=hypha

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+helm-charts/*.tgz
 **/.minio.sys
 *.DS_Store
 *.app

--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -52,6 +52,21 @@ To uninstall the chart:
 helm uninstall hypha-server --namespace=hypha
 ```
 
+### Install Released Helm Charts
+
+You can also install the released helm charts from the [hypha helm repository](https://amun-ai.github.io/hypha/helm-charts):
+
+```bash
+helm repo add hypha https://amun-ai.github.io/hypha/helm-charts
+helm repo update
+helm install hypha-server hypha/hypha-server --namespace=hypha
+```
+
+To override the values, you can prepare a `values.yaml` file with the values you want to override and install the helm chart with the following command:
+```bash
+helm install hypha-server hypha/hypha-server --namespace=hypha -f values.yaml
+```
+
 ## Install Redis for scaling
 
 Hypha can use an external Redis to store global state and pub/sub messages shared between the server instances.

--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -74,7 +74,23 @@ startupCommand:
     - "--redis-uri=redis://redis.hypha.svc.cluster.local:6379/0"
 ```
 
-Now, upgrade the helm chart:
+To actually support multiple server instances, you need to set the `replicaCount` to more than 1 in the `values.yaml` file:
+
+```yaml
+replicaCount: 3
+```
+
+You also need to set the `HYPHA_SERVER_ID` environment variable to the pod's UID in the `values.yaml` file:
+```yaml
+env:
+  - name: HYPHA_SERVER_ID
+    valueFrom:
+      # Use the pod's UID as the server ID
+      fieldRef:
+        fieldPath: metadata.uid
+```
+
+Make sure to update the `values.yaml` file with the correct `redis-uri` and `replicaCount`, and add the `HYPHA_SERVER_ID` environment variable, then upgrade the helm chart:
 ```bash
 helm upgrade hypha-server ./hypha-server --namespace=hypha
 ```

--- a/helm-charts/aks-hypha.md
+++ b/helm-charts/aks-hypha.md
@@ -218,9 +218,18 @@ First, install the Redis Helm chart:
 helm install redis ./redis --namespace hypha
 ```
 
-This will install Redis in the `hypha` namespace, make sure you update the `values.yaml` file to add the `redis-uri` to the `startupCommand`:
+This will install Redis in the `hypha` namespace, make sure you update the `values.yaml` file to add the `redis-uri` to the `startupCommand`, set the `replicaCount` to more than 1, and add the `HYPHA_SERVER_ID` environment variable (using the pod id).
   
 ```yaml
+replicaCount: 2
+
+env:
+  - name: HYPHA_SERVER_ID
+    valueFrom:
+      fieldRef:
+        # Use the pod's UID as the server ID
+        fieldPath: metadata.uid
+
 startupCommand:
   command: ["python", "-m", "hypha.server"]
   args:

--- a/helm-charts/hypha-server/Chart.yaml
+++ b/helm-charts/hypha-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.20.35
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/hypha-server/values.yaml
+++ b/helm-charts/hypha-server/values.yaml
@@ -117,5 +117,3 @@ startupCommand:
     - "--port=9520"
     - "--public-base-url=$(PUBLIC_BASE_URL)"
     # - "--redis-uri=redis://redis.hypha.svc.cluster.local:6379/0"
-    - "--server-id=$(HYPHA_SERVER_ID)"
-    

--- a/helm-charts/hypha-server/values.yaml
+++ b/helm-charts/hypha-server/values.yaml
@@ -102,6 +102,12 @@ env:
         key: JWT_SECRET
   - name: PUBLIC_BASE_URL
     value: "https://hypha.amun.ai"
+  # Use the pod's UID as the server ID
+  # This is important to ensure Hypha Server can handle multiple replicas
+  - name: HYPHA_SERVER_ID
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.uid
 
 # Define command-line arguments here
 startupCommand:
@@ -111,4 +117,5 @@ startupCommand:
     - "--port=9520"
     - "--public-base-url=$(PUBLIC_BASE_URL)"
     # - "--redis-uri=redis://redis.hypha.svc.cluster.local:6379/0"
+    - "--server-id=$(HYPHA_SERVER_ID)"
     

--- a/hypha/VERSION
+++ b/hypha/VERSION
@@ -1,3 +1,3 @@
 {
-    "version": "0.20.35.post2"
+    "version": "0.20.35.post3"
 }

--- a/hypha/card.py
+++ b/hypha/card.py
@@ -35,15 +35,6 @@ class CardController:
         self.workspace_bucket = workspace_bucket
 
         self.s3client = self.s3_controller.create_client_sync()
-
-        try:
-            self.s3client.create_bucket(Bucket=self.workspace_bucket)
-            logger.info("Bucket created: %s", self.workspace_bucket)
-        except self.s3client.exceptions.BucketAlreadyExists:
-            pass
-        except self.s3client.exceptions.BucketAlreadyOwnedByYou:
-            pass
-
         router = APIRouter()
 
         @router.get("/{workspace}/cards/{path:path}")

--- a/hypha/core/__init__.py
+++ b/hypha/core/__init__.py
@@ -51,6 +51,7 @@ class ServiceConfig(BaseModel):
     workspace: Optional[str] = None
     flags: List[str] = []
     singleton: Optional[bool] = False
+    created_by: Optional[Dict] = None
 
 
 class ServiceInfo(BaseModel):

--- a/hypha/core/auth.py
+++ b/hypha/core/auth.py
@@ -137,9 +137,9 @@ def valid_token(authorization: str):
             status_code=401, detail="The token has expired. Please fetch a new one"
         ) from err
     except jwt.JWTError as err:
-        raise HTTPException(status_code=401, detail=traceback.format_exc()) from err
+        raise HTTPException(status_code=401, detail=str(err)) from err
     except Exception as err:
-        raise HTTPException(status_code=401, detail=traceback.format_exc()) from err
+        raise HTTPException(status_code=401, detail=str(err)) from err
 
 
 def generate_anonymous_user(scope=None) -> UserInfo:

--- a/hypha/core/store.py
+++ b/hypha/core/store.py
@@ -430,6 +430,9 @@ class RedisStore:
             await self._run_startup_functions(startup_functions)
         self._ready = True
         await self.get_event_bus().emit_local("startup")
+        servers = await self.list_servers()
+        logger.info("Server initialized with server id: %s", self._server_id)
+        logger.info("Currently connected hypha servers: %s", servers)
 
     async def _register_root_services(self):
         """Register root services."""

--- a/hypha/core/store.py
+++ b/hypha/core/store.py
@@ -117,7 +117,7 @@ class RedisStore:
             "auth0_issuer": AUTH0_ISSUER,
             "login_service_url": f"{self.public_base_url}{LOGIN_SERVICE_URL}",
         }
-        
+
         logger.info("Server info: %s", self._server_info)
 
         if redis_uri and redis_uri.startswith("redis://"):
@@ -656,7 +656,11 @@ class RedisStore:
         logger.info("Creating RPC for client %s", client_id)
         assert user_info is not None, "User info is required"
         connection = RedisRPCConnection(
-            self._event_bus, workspace, client_id, user_info, manager_id=self._manager_id,
+            self._event_bus,
+            workspace,
+            client_id,
+            user_info,
+            manager_id=self._manager_id,
         )
         rpc = RPC(
             connection,

--- a/hypha/core/store.py
+++ b/hypha/core/store.py
@@ -106,6 +106,7 @@ class RedisStore:
         self._server_id = server_id or "server-0"
         self.reconnection_token_life_time = reconnection_token_life_time
         self._server_info = {
+            "server_id": self._server_id,
             "hypha_version": __version__,
             "public_base_url": self.public_base_url,
             "local_base_url": self.local_base_url,
@@ -115,6 +116,8 @@ class RedisStore:
             "auth0_issuer": AUTH0_ISSUER,
             "login_service_url": f"{self.public_base_url}{LOGIN_SERVICE_URL}",
         }
+        
+        logger.info("Server info: %s", self._server_info)
 
         if redis_uri and redis_uri.startswith("redis://"):
             from redis import asyncio as aioredis

--- a/hypha/core/store.py
+++ b/hypha/core/store.py
@@ -189,7 +189,6 @@ class RedisStore:
                     "read_only": user_info.is_anonymous,
                 }
             )
-            logger.info(f"Created workspace: {workspace}")
         else:
             if not workspace_info:
                 raise KeyError(
@@ -599,7 +598,7 @@ class RedisStore:
             self._root_user,
             self._event_bus,
             self._server_info,
-            self._server_id,
+            "manager-" + self._server_id,
             self._s3_controller,
         )
         await manager.setup()
@@ -656,7 +655,7 @@ class RedisStore:
         logger.info("Creating RPC for client %s", client_id)
         assert user_info is not None, "User info is required"
         connection = RedisRPCConnection(
-            self._event_bus, workspace, client_id, user_info, manager_id=self._server_id
+            self._event_bus, workspace, client_id, user_info, manager_id=self.get_manager_id()
         )
         rpc = RPC(
             connection,

--- a/hypha/core/store.py
+++ b/hypha/core/store.py
@@ -104,6 +104,7 @@ class RedisStore:
         self._workspace_manager = None
         self._websocket_server = None
         self._server_id = server_id or random_id(readable=True)
+        self._manager_id = "manager-" + self._server_id
         self.reconnection_token_life_time = reconnection_token_life_time
         self._server_info = {
             "server_id": self._server_id,
@@ -598,7 +599,7 @@ class RedisStore:
             self._root_user,
             self._event_bus,
             self._server_info,
-            "manager-" + self._server_id,
+            self._manager_id,
             self._s3_controller,
         )
         await manager.setup()
@@ -655,7 +656,7 @@ class RedisStore:
         logger.info("Creating RPC for client %s", client_id)
         assert user_info is not None, "User info is required"
         connection = RedisRPCConnection(
-            self._event_bus, workspace, client_id, user_info, manager_id=self.get_manager_id()
+            self._event_bus, workspace, client_id, user_info, manager_id=self._manager_id,
         )
         rpc = RPC(
             connection,

--- a/hypha/core/store.py
+++ b/hypha/core/store.py
@@ -365,7 +365,7 @@ class RedisStore:
             await self._redis.flushall()
         await self._event_bus.init()
         await self.setup_root_user()
-        await self.check_and_cleanup_servers()
+        # await self.check_and_cleanup_servers()
         self._workspace_manager = await self.register_workspace_manager()
 
         try:

--- a/hypha/core/store.py
+++ b/hypha/core/store.py
@@ -103,7 +103,7 @@ class RedisStore:
         self._ready = False
         self._workspace_manager = None
         self._websocket_server = None
-        self._server_id = server_id or "server-0"
+        self._server_id = server_id or random_id(readable=True)
         self.reconnection_token_life_time = reconnection_token_life_time
         self._server_info = {
             "server_id": self._server_id,
@@ -365,7 +365,7 @@ class RedisStore:
             await self._redis.flushall()
         await self._event_bus.init()
         await self.setup_root_user()
-        # await self.check_and_cleanup_servers()
+        await self.check_and_cleanup_servers()
         self._workspace_manager = await self.register_workspace_manager()
 
         try:

--- a/hypha/core/workspace.py
+++ b/hypha/core/workspace.py
@@ -64,6 +64,7 @@ class WorkspaceManager:
         root_user: UserInfo,
         event_bus: EventBus,
         server_info: dict,
+        client_id: str,
         s3_controller: Optional[S3Controller] = None,
     ):
         self._redis = redis
@@ -72,11 +73,11 @@ class WorkspaceManager:
         self._root_user = root_user
         self._event_bus = event_bus
         self._server_info = server_info
-        self._client_id = None
+        self._client_id = client_id
         self._s3_controller = s3_controller
 
     def get_client_id(self):
-        assert self._client_id is not None, "Manager client id not set."
+        assert self._client_id, "client id must not be empty."
         return self._client_id
 
     async def setup(
@@ -87,7 +88,7 @@ class WorkspaceManager:
         """Setup the workspace manager."""
         if self._initialized:
             return self._rpc
-        self._client_id = "ws-" + random_id(readable=False)
+        assert self._client_id, "client id must be provided."
         rpc = self._create_rpc(self._client_id)
         self._rpc = rpc
         management_service = self.create_service(service_id, service_name)

--- a/hypha/core/workspace.py
+++ b/hypha/core/workspace.py
@@ -788,7 +788,7 @@ class WorkspaceManager:
         service_exists = await self._redis.exists(
             f"services:*|*:{service.id}@{service.app_id}"
         )
-        key = f"services:{service.config.visibility.value}|{service.type}:{service.id}@{service.app_id}"
+        key = f"services:{service.config.visibility}|{service.type}:{service.id}@{service.app_id}"
         await self._redis.hset(key, mapping=service.to_redis_dict())
 
         if service_exists:
@@ -923,7 +923,7 @@ class WorkspaceManager:
         assert ":" in service.id, "Service id info must contain ':'"
         service.app_id = service.app_id or "*"
         service.type = service.type or "*"
-        key = f"services:{service.config.visibility.value}|{service.type}:{service.id}@{service.app_id}"
+        key = f"services:{service.config.visibility}|{service.type}:{service.id}@{service.app_id}"
         logger.info("Removing service: %s", key)
 
         # Check if the service exists before removal

--- a/hypha/core/workspace.py
+++ b/hypha/core/workspace.py
@@ -788,7 +788,8 @@ class WorkspaceManager:
         service_exists = await self._redis.exists(
             f"services:*|*:{service.id}@{service.app_id}"
         )
-        key = f"services:{service.config.visibility}|{service.type}:{service.id}@{service.app_id}"
+        visibility = service.config.visibility if isinstance(service.config.visibility, str) else service.config.visibility.value
+        key = f"services:{visibility}|{service.type}:{service.id}@{service.app_id}"
         await self._redis.hset(key, mapping=service.to_redis_dict())
 
         if service_exists:
@@ -923,7 +924,8 @@ class WorkspaceManager:
         assert ":" in service.id, "Service id info must contain ':'"
         service.app_id = service.app_id or "*"
         service.type = service.type or "*"
-        key = f"services:{service.config.visibility}|{service.type}:{service.id}@{service.app_id}"
+        visibility = service.config.visibility if isinstance(service.config.visibility, str) else service.config.visibility.value
+        key = f"services:{visibility}|{service.type}:{service.id}@{service.app_id}"
         logger.info("Removing service: %s", key)
 
         # Check if the service exists before removal

--- a/hypha/core/workspace.py
+++ b/hypha/core/workspace.py
@@ -784,11 +784,9 @@ class WorkspaceManager:
                 )
                 return
         # Check if the service already exists
-        service_exists = await self._redis.keys(
-            f"services:*|*:{service.id}@*"
-        )
+        service_exists = await self._redis.keys(f"services:*|*:{service.id}@*")
         key = f"services:{service.config.visibility.value}|{service.type}:{service.id}@{service.app_id}"
-        
+
         if service_exists:
             # remove all the existing services
             # This is needed because it is maybe registered with a different app_id

--- a/hypha/core/workspace.py
+++ b/hypha/core/workspace.py
@@ -275,9 +275,14 @@ class WorkspaceManager:
             )
 
         # clean up the user's workspace
-        summary = await self.cleanup(workspace.id, context={"ws": workspace.id, "user": self._root_user.model_dump()})
+        summary = await self.cleanup(
+            workspace.id,
+            context={"ws": workspace.id, "user": self._root_user.model_dump()},
+        )
         if summary:
-            logger.info("Created workspace %s, clean up summary: %s", workspace.id, summary)
+            logger.info(
+                "Created workspace %s, clean up summary: %s", workspace.id, summary
+            )
         else:
             logger.info("Created workspace %s", workspace.id)
         return workspace.model_dump()
@@ -1403,7 +1408,9 @@ class WorkspaceManager:
             workspace = ws
         user_info = UserInfo.model_validate(context["user"])
         if not user_info.check_permission(workspace, UserPermission.admin):
-            raise PermissionError(f"Permission denied for workspace {workspace}, user: {user_info.id}")
+            raise PermissionError(
+                f"Permission denied for workspace {workspace}, user: {user_info.id}"
+            )
         # list all the clients and ping them
         # If they are not responding, delete them
         client_keys = await self._list_client_keys(workspace)

--- a/hypha/core/workspace.py
+++ b/hypha/core/workspace.py
@@ -250,7 +250,7 @@ class WorkspaceManager:
             workspace.owners.append(user_info.id)
         self._validate_workspace_id(workspace.id, with_hyphen=user_info.id != "root")
         # make sure we add the user's email to owners
-        _id = user_info.email or user_info.id
+        _id = user_info.id
         if _id not in workspace.owners:
             workspace.owners.append(_id)
         workspace.owners = [o.strip() for o in workspace.owners if o.strip()]

--- a/hypha/core/workspace.py
+++ b/hypha/core/workspace.py
@@ -788,8 +788,7 @@ class WorkspaceManager:
         service_exists = await self._redis.exists(
             f"services:*|*:{service.id}@{service.app_id}"
         )
-        visibility = service.config.visibility if isinstance(service.config.visibility, str) else service.config.visibility.value
-        key = f"services:{visibility}|{service.type}:{service.id}@{service.app_id}"
+        key = f"services:{service.config.visibility.value}|{service.type}:{service.id}@{service.app_id}"
         await self._redis.hset(key, mapping=service.to_redis_dict())
 
         if service_exists:
@@ -924,8 +923,7 @@ class WorkspaceManager:
         assert ":" in service.id, "Service id info must contain ':'"
         service.app_id = service.app_id or "*"
         service.type = service.type or "*"
-        visibility = service.config.visibility if isinstance(service.config.visibility, str) else service.config.visibility.value
-        key = f"services:{visibility}|{service.type}:{service.id}@{service.app_id}"
+        key = f"services:{service.config.visibility.value}|{service.type}:{service.id}@{service.app_id}"
         logger.info("Removing service: %s", key)
 
         # Check if the service exists before removal

--- a/hypha/core/workspace.py
+++ b/hypha/core/workspace.py
@@ -576,7 +576,7 @@ class WorkspaceManager:
         if isinstance(query, str):
             visibility = "*"
             type_filter = "*"
-            workspace = "*"
+            workspace = cws
             client_id = "*"
             service_id = "*"
 
@@ -643,7 +643,7 @@ class WorkspaceManager:
 
         # Automatically limit visibility to public if workspace is "*"
         original_visibility = query.get("visibility", "*")
-        workspace = query.get("workspace", "*")
+        workspace = query.get("workspace", cws)
         if workspace == "*":
             assert (
                 original_visibility != "protected"

--- a/hypha/http.py
+++ b/hypha/http.py
@@ -104,7 +104,7 @@ async def extracted_kwargs(
         if use_function_kwargs:
             kwargs = json.loads(kwargs.get("function_kwargs", "{}"))
         else:
-            for key in kwargs:
+            for key in list(kwargs.keys()):
                 if key in ["workspace", "service_id", "function_key", "_mode"]:
                     del kwargs[key]
                 else:
@@ -125,7 +125,7 @@ async def extracted_kwargs(
             kwargs = kwargs.get("function_kwargs", {})
         else:
             for key in ["workspace", "service_id", "function_key", "_mode"]:
-                if key in kwargs:
+                if key in list(kwargs.keys()):
                     del kwargs[key]
     else:
         raise RuntimeError(f"Invalid request method: {request.method}")

--- a/hypha/http.py
+++ b/hypha/http.py
@@ -359,6 +359,14 @@ class ASGIRoutingMiddleware:
                         ],
                     }
                 )
+                await send(
+                    {
+                        "type": "http.response.body",
+                        "body": b"Internal Server Error: "
+                        + traceback.format_exc().encode(),
+                        "more_body": False,
+                    }
+                )
         else:
             await send(
                 {
@@ -367,6 +375,13 @@ class ASGIRoutingMiddleware:
                     "headers": [
                         [b"content-type", b"text/plain"],
                     ],
+                }
+            )
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": b"Function not found: " + func_name.encode(),
+                    "more_body": False,
                 }
             )
 

--- a/hypha/server.py
+++ b/hypha/server.py
@@ -217,6 +217,7 @@ def create_application(args):
 
     store = RedisStore(
         application,
+        server_id=args.server_id,
         public_base_url=public_base_url,
         local_base_url=local_base_url,
         redis_uri=args.redis_uri,
@@ -395,6 +396,12 @@ def get_argparser(add_help=True):
         type=str,
         nargs="*",
         help="Specifies one or more startup functions. Each URI should be in the format '<python module or script>:<entrypoint function name>'. These functions are executed at server startup to perform initialization tasks such as loading services, configuring the server, or launching additional processes.",
+    )
+    parser.add_argument(
+        "--server-id",
+        type=str,
+        default=None,
+        help="The server ID of this instance, used to distinguish between multiple instances of hypha server in a distributed environment",
     )
 
     return parser

--- a/hypha/server.py
+++ b/hypha/server.py
@@ -217,7 +217,7 @@ def create_application(args):
 
     store = RedisStore(
         application,
-        server_id=args.server_id,
+        server_id=args.server_id or env.get("HYPHA_SERVER_ID"),
         public_base_url=public_base_url,
         local_base_url=local_base_url,
         redis_uri=args.redis_uri,

--- a/hypha/templates/ws/code_template.html
+++ b/hypha/templates/ws/code_template.html
@@ -1,33 +1,31 @@
 <config lang="json">
 {
-    "name": "Untitled Plugin",
-    "type": "web-python",
-    "version": "0.1.0",
-    "description": "[TODO: describe this plugin with one sentence.]",
+    "name": "Untitled App",
+    "type": "web-worker",
     "tags": [],
     "ui": "",
+    "version": "0.1.0",
     "cover": "",
-    "inputs": null,
-    "outputs": null,
-    "flags": [],
+    "description": "[TODO: describe this app with one sentence.]",
     "icon": "extension",
     "api_version": "0.1.8",
-    "env": "",
-    "permissions": [],
-    "requirements": [],
+    "requirements": ["https://cdn.jsdelivr.net/npm/hypha-rpc@latest/dist/hypha-rpc-websocket.min.js"],
     "dependencies": []
 }
 </config>
-    
-<script lang="python">
-from hypha_rpc import api, connect_to_server
 
-async def setup():
-    server_config = await api.get_server_config()
-    server = await connect_to_server(server_config)
-    # now you can use the server object to interact with the server
-    await api.alert(await server.echo("Hello World!"))
+<script lang="javascript">
+class HyphaApp {
+    async setup() {
+        const serverConfig = await api.getServerConfig()
+        const server = await hyphaWebsocketClient.connectToServer(serverConfig)
+        // now you can use the server object to interact with the server
+        await api.alert(await server.echo("Hello World!"))
+        
+        await server.disconnect()
+    }
+}
 
-api.export({"setup": setup})
+api.export(new HyphaApp())
 </script>
-
+    

--- a/hypha/templates/ws/index.html
+++ b/hypha/templates/ws/index.html
@@ -243,7 +243,13 @@
                     </div>
                     <div className="text-gray-400 whitespace-pre-wrap break-words w-full">
                         <p className="mb-4">
-                            <strong>Client ID:</strong> {client}
+                            <strong>Client ID:</strong> {client.id.split('/')[1]}
+                        </p>
+                        <p className="mb-4">
+                            {client.user && (<strong>User:</strong>)} {client.user && client.user.id}
+                        </p>
+                        <p className="mb-4">
+                            {client.user && (<strong>Email:</strong>)} {client.user && client.user.email}
                         </p>
                     </div>
                 </div>
@@ -906,19 +912,6 @@
                             )}
                             <hr className="my-8 border-gray-700"></hr>
                             <div className="flex items-center mb-6">
-                                <i className="fas fa-cogs fa-2x text-green-400 mr-3"></i>
-                                <h2 className="text-2xl font-bold">Services</h2>
-                            </div>
-                            <p className="text-xl text-gray-400 mt-4">
-                                Services available in workspace: <code>{workspaceId}</code>
-                            </p>
-                            <div className="grid grid-cols-1 md:grid-cols-1 lg:grid-cols-2 gap-8 mt-6">
-                                {services.map(service => (
-                                    <ServiceCard key={service.id} service={service} onBookmarkService={handleBookmarkService} onShowDetails={onShowDetails} />
-                                ))}
-                            </div>                            
-                            <hr className="my-8 border-gray-700"></hr>
-                            <div className="flex items-center mb-6">
                                 <i className="fas fa-users fa-2x text-yellow-400 mr-3"></i>
                                 <h2 className="text-2xl font-bold">Clients</h2>
                             </div>
@@ -927,7 +920,27 @@
                             </p>
                             <div className="grid grid-cols-1 md:grid-cols-1 lg:grid-cols-2 gap-8 mt-6">
                                 {clients.map(client => (
-                                    <ClientCard key={client} client={client} />
+                                    <ClientCard key={client.id} client={client} />
+                                ))}
+                            </div>
+                            <hr className="my-8 border-gray-700"></hr>
+                            <div className="flex items-center mb-6">
+                                <i className="fas fa-cogs fa-2x text-green-400 mr-3"></i>
+                                <h2 className="text-2xl font-bold">Services</h2>
+                            </div>
+                            <p className="text-xl text-gray-400 mt-4">
+                                Services available in workspace: <code>{workspaceId}</code>
+                            </p>
+                            <div className="grid grid-cols-1 md:grid-cols-1 lg:grid-cols-2 gap-8 mt-6">
+                                {services.map(service => (
+                                    service.type !== "built-in" && (
+                                        <ServiceCard 
+                                            key={service.id} 
+                                            service={service} 
+                                            onBookmarkService={handleBookmarkService} 
+                                            onShowDetails={onShowDetails} 
+                                        />
+                                    )
                                 ))}
                             </div>
                         </>

--- a/hypha/templates/ws/index.html
+++ b/hypha/templates/ws/index.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
     <script src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
     <script src="https://rawcdn.githack.com/nextapps-de/winbox/0.2.82/dist/winbox.bundle.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/1.7.7/axios.min.js"></script>
     <!-- Favicon and Icons -->
     <link rel="apple-touch-icon" sizes="180x180" href="./static/img/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="./static/img/favicon-32x32.png">
@@ -317,22 +318,41 @@
             );
         };
 
-        const FileCard = ({ file, onGenerateUrl }) => {
+        const FileCard = ({ file, onDownload, onDelete, uploadProgress }) => {
             return (
-                <div className="flex justify-between items-center p-4 bg-gray-700 rounded-lg shadow-lg mb-4">
-                    <div>
-                        <i className="fas fa-file-alt mr-2"></i>
-                        {file.name}
-                    </div>
-                    <button
-                        className="bg-blue-600 hover:bg-blue-500 text-white font-bold py-2 px-4 rounded-full transition duration-300"
-                        onClick={() => onGenerateUrl(file.name)}
-                    >
-                        <i className="fas fa-share"></i>
-                    </button>
+              <div className="flex justify-between items-center p-4 bg-gray-700 rounded-lg shadow-lg mb-4">
+                <div>
+                  <i className="fas fa-file-alt mr-2"></i>
+                  {file.name}
                 </div>
+                {uploadProgress[file.name] && (
+                  <div className="w-1/2">
+                    <div className="w-full bg-gray-600 h-2 rounded">
+                      <div
+                        className="bg-blue-500 h-2 rounded"
+                        style={{ width: `${uploadProgress[file.name]}%` }}
+                      ></div>
+                    </div>
+                  </div>
+                )}
+                <div className="flex">
+                  <button
+                    className="bg-blue-600 hover:bg-blue-500 text-white font-bold py-2 px-4 rounded-full transition duration-300"
+                    onClick={() => onDownload(file)}
+                  >
+                    <i className="fas fa-download"></i>
+                  </button>
+                  <button
+                    className="bg-red-600 hover:bg-red-500 text-white font-bold py-2 px-4 rounded-full transition duration-300 ml-2"
+                    onClick={() => onDelete(file)}
+                    >
+                    <i className="fas fa-trash"></i>
+                  </button>
+                </div>
+              </div>
             );
         };
+                 
 
         const Modal = ({ serviceInfo, onClose }) => {
             return (
@@ -646,7 +666,7 @@
             );
         };
         
-        const MainContent = ({ isCollapsed, enabledPanels, ws, workspaceId, panel, clients, services, apps, files, onGenerateUrl, onShowDetails, onInstallApp }) => {
+        const MainContent = ({ isCollapsed, enabledPanels, ws, s3, workspaceId, panel, clients, services, apps, files, onShowDetails, onInstallApp }) => {
 
             const [workspaces, setWorkspaces] = React.useState([]);
             const [showCreateModal, setShowCreateModal] = React.useState(false);
@@ -654,6 +674,12 @@
             const [editingWorkspace, setEditingWorkspace] = React.useState(null);
             const [currentWorkspaceInfo, setCurrentWorkspaceInfo] = React.useState(null);
             const [bookmarkedItems, setBookmarkedItems] = React.useState([]);
+            const [uploadProgress, setUploadProgress] = React.useState({});
+            const [fileList, setFileList] = React.useState(files);
+
+            React.useEffect(() => {
+                setFileList(files); // Keep file list updated
+            }, [files]);
 
             React.useEffect(() => {
                 const fetchWorkspaces = async () => {
@@ -773,9 +799,81 @@
                     alert(`Failed to unbookmark workspace: ${error.message}`);
                 }
             };
+
+            const handleFileDrop = async (e) => {
+                e.preventDefault();
+                const droppedFiles = e.dataTransfer.files;
+                for (const file of droppedFiles) {
+                  await handleFileUpload(file);
+                }
+              };
+            
+              const handleFileUpload = async (file) => {
+                try {
+                  const presignedUrl = await s3.generatePresignedUrl(file.name, "put_object");
+                  const token = config.token; // Assuming token is stored in config
+            
+                  const response = await axios.put(presignedUrl, file, {
+                    headers: {
+                      "Content-Type": file.type || "application/octet-stream",
+                    },
+                    onUploadProgress: (progressEvent) => {
+                      if (!progressEvent.total) return;
+                      const progress = (progressEvent.loaded / progressEvent.total) * 100;
+                      setUploadProgress((prev) => ({ ...prev, [file.name]: progress }));
+                    },
+                  });
+            
+                  if (response.status === 200) {
+                    console.log(`File ${file.name} uploaded successfully`);
+                    setFileList(await s3.listFiles()); // Refresh file list after successful upload
+                  } else {
+                    console.error("File upload failed", response.statusText);
+                  }
+                } catch (error) {
+                  console.error("File upload failed", error);
+                }
+              };
+            
+              const handleFileDownload = async (file) => {
+                try {
+                  if(file.type === 'directory'){
+                    alert('Cannot download a directory');
+                    return;
+                  }
+                  const presignedUrl = await s3.generatePresignedUrl(file.name, "get_object");
+                  window.open(presignedUrl, '_blank'); // Trigger file download
+                } catch (error) {
+                  console.error("Failed to generate download link", error);
+                }
+              };
+
+              const handleFileDelete = async (file) => {
+                try {
+                    let anwser;
+                    if(file.type === 'directory'){
+                        anwser = confirm(`Are you sure you want to delete the directory ${file.name} and all its contents?`);
+                    } else {
+                        anwser = confirm(`Are you sure you want to delete the file ${file.name}?`);
+                    }
+                    if(!anwser) return;
+                    if (file.type === 'directory') {
+                        await s3.deleteDirectory(file.name);
+                    } else {
+                        await s3.deleteFile(file.name);
+                    }
+                    setFileList(await s3.listFiles()); // Refresh file list after successful delete
+                } catch (error) {
+                  console.error("Failed to delete file", error);
+                }
+              };
         
             return (
-                <div className={`main-content transition-all duration-300 ${isCollapsed ? 'ml-16' : 'ml-64'}`}>
+                <div
+                    className={`main-content transition-all duration-300 ${isCollapsed ? 'ml-16' : 'ml-64'}`}
+                    onDrop={handleFileDrop}
+                    onDragOver={(e) => e.preventDefault()} // Prevent default to allow drop
+                >
                     {panel === 'dashboard' && (
                         <>
                             <h1 className="text-4xl font-bold capitalize">Dashboard</h1>
@@ -969,19 +1067,30 @@
         
                     {panel === 'files' && (
                         <>
-                            <h1 className="text-4xl font-bold capitalize">Files</h1>
-                            <p className="text-xl text-gray-400 mt-4">
-                                Files in workspace: <code>{workspaceId}</code>
+                        <h1 className="text-4xl font-bold capitalize">Files</h1>
+                        <p className="text-xl text-gray-400 mt-4">
+                            Files in workspace: <code>{workspaceId}</code>
+                        </p>
+                        <div className="p-4 border-dashed border-4 border-gray-600 rounded mt-6">
+                            <p className="text-center text-gray-500">
+                            Drag and drop files here to upload
                             </p>
-                            <div className="mt-6">
-                                {files.length === 0 ? (
-                                    <p>No files available.</p>
-                                ) : (
-                                    files.map(file => (
-                                        <FileCard key={file.name} file={file} onGenerateUrl={onGenerateUrl} />
-                                    ))
-                                )}
-                            </div>
+                        </div>
+                        <div className="mt-6">
+                            {fileList.length === 0 ? (
+                            <p>No files available.</p>
+                            ) : (
+                            fileList.map((file) => (
+                                <FileCard
+                                key={file.name}
+                                file={file}
+                                uploadProgress={uploadProgress}
+                                onDownload={handleFileDownload}
+                                onDelete={handleFileDelete}
+                                />
+                            ))
+                            )}
+                        </div>
                         </>
                     )}
         
@@ -1096,6 +1205,7 @@
             const [apps, setApps] = React.useState([]);
             const [files, setFiles] = React.useState([]);
             const [ws, setWs] = React.useState(null);
+            const [s3, setS3] = React.useState(null);
             const [selectedService, setSelectedService] = React.useState(null);
         
             React.useEffect(() => {
@@ -1113,8 +1223,9 @@
                             console.log("Server apps service not available");
                         }
                         try {
-                            await remoteServer.getService('public/s3-storage', { case_conversion: 'camel' });
+                            const s3 = await remoteServer.getService('public/s3-storage', { case_conversion: 'camel' });
                             newPanels.push('files');
+                            setS3(s3);
                         }
                         catch(e){
                             console.log("S3 storage service not available");
@@ -1149,7 +1260,7 @@
                     } else if (activePanel === 'files') {
                         try {
                             const s3 = await ws.getService('public/s3-storage', { case_conversion: 'camel' });
-                            const files = await s3.listFiles('');
+                            const files = await s3.listFiles();
                             setFiles(files);
                         } catch (e) {
                             alert(`Failed to list files: ${e.message}`);
@@ -1159,11 +1270,6 @@
                 fetchWorkspaceData();
                 document.title = `${activePanel.charAt(0).toUpperCase() + activePanel.slice(1)} - Hypha Workspace Management`;
             }, [activePanel, ws]);
-
-            const onGenerateUrl = async (fileName) => {
-                const presignedUrl = await ws.generatePresignedUrl(fileName);
-                console.log('Presigned URL:', presignedUrl);
-            };
         
             const onShowDetails = (service) => {
                 setSelectedService(service);
@@ -1212,13 +1318,13 @@
                         isCollapsed={isCollapsed}
                         enabledPanels={enabledPanels}
                         ws={ws}
+                        s3={s3}
                         workspaceId={config.workspace}
                         panel={activePanel}
                         clients={clients}
                         services={services}
                         apps={apps}
                         files={files}
-                        onGenerateUrl={onGenerateUrl}
                         onShowDetails={onShowDetails}
                         onInstallApp={onInstallApp}
                     />

--- a/hypha/websocket.py
+++ b/hypha/websocket.py
@@ -268,7 +268,7 @@ class WebsocketServer:
                 "hypha_version": __version__,
                 "public_base_url": self.store.public_base_url,
                 "local_base_url": self.store.local_base_url,
-                "manager_id": self.store.manager_id,
+                "manager_id": self.store.get_manager_id(),
                 "workspace": workspace,
                 "client_id": client_id,
                 "user": user_info.model_dump(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,6 +208,7 @@ def fastapi_server_redis_1(redis_server, minio_server):
             # "--enable-s3",
             # need to define it so the two server can communicate
             f"--public-base-url=http://my-public-url.com",
+            "--server-id=server-0",
             f"--redis-uri=redis://127.0.0.1:{REDIS_PORT}/0",
             "--reset-redis",
             # f"--endpoint-url={MINIO_SERVER_URL}",
@@ -249,6 +250,7 @@ def fastapi_server_redis_2(redis_server, minio_server, fastapi_server):
             # "--enable-s3",
             # need to define it so the two server can communicate
             f"--public-base-url=http://my-public-url.com",
+            "--server-id=server-1",
             f"--redis-uri=redis://127.0.0.1:{REDIS_PORT}/0",
             # f"--endpoint-url={MINIO_SERVER_URL}",
             # f"--access-key-id={MINIO_ROOT_USER}",

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 import httpx
 import requests
+import asyncio
 from hypha_rpc.websocket_client import connect_to_server
 
 from . import WS_SERVER_URL, SERVER_URL, find_item
@@ -60,7 +61,7 @@ async def test_http_services(minio_server, fastapi_server, test_user_token):
         {
             "name": "test client",
             "server_url": WS_SERVER_URL,
-            "method_timeout": 10,
+            "method_timeout": 30,
             "token": test_user_token,
         }
     )

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -67,9 +67,9 @@ async def test_http_services(minio_server, fastapi_server, test_user_token):
     workspace = api.config["workspace"]
     svc = await api.register_service(
         {
-            "id": "test_service",
-            "name": "test_service",
-            "type": "test_service",
+            "id": "my_service",
+            "name": "my_service",
+            "type": "my_service",
             "config": {
                 "visibility": "public",
             },
@@ -85,7 +85,7 @@ async def test_http_services(minio_server, fastapi_server, test_user_token):
         data = await client.get(f"{SERVER_URL}/{workspace}/services")
         # [{'config': {'visibility': 'public', 'require_context': False, 'workspace': 'VRRVEdTF9of2y4cLmepzBw', 'flags': []}, 'id': '5XCPAyZrW72oBzywEk2oxP:test_service', 'name': 'test_service', 'type': 'test_service', 'description': '', 'docs': {}}]
         assert data.status_code == 200
-        assert find_item(data.json(), "name", "test_service")
+        assert find_item(data.json(), "name", "my_service")
 
     await api.disconnect()
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -72,6 +72,7 @@ async def test_http_services(minio_server, fastapi_server, test_user_token):
             "type": "my_service",
             "config": {
                 "visibility": "public",
+                "run_in_executor": True,
             },
             "echo": lambda data: data,
         }

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -193,7 +193,7 @@ async def test_http_proxy(
     assert not response.ok
 
     response = requests.get(
-        f"{SERVER_URL}/{service_ws}/services/test_service/echo?v=3345"
+        f"{SERVER_URL}/{service_ws}/services/test_service/echo?v=3345&_mode=first"
     )
     assert response.ok, response.json()["detail"]
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -77,6 +77,7 @@ async def test_http_services(minio_server, fastapi_server, test_user_token):
             "echo": lambda data: data,
         }
     )
+    await asyncio.sleep(0.5)
     async with httpx.AsyncClient(timeout=20.0) as client:
         url = f"{SERVER_URL}/{workspace}/services/{svc.id.split('/')[1]}/echo"
         data = await client.post(url, json={"data": "123"})

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -191,14 +191,16 @@ async def test_http_proxy(
     )
     print(response.text)
     assert not response.ok
+    
+    service_id = svc1.id.split("/")[-1]
 
     response = requests.get(
-        f"{SERVER_URL}/{service_ws}/services/test_service/echo?v=3345&_mode=first"
+        f"{SERVER_URL}/{service_ws}/services/{service_id}/echo?v=3345"
     )
     assert response.ok, response.json()["detail"]
 
     response = requests.get(
-        f"{SERVER_URL}/{service_ws}/services/test_service/echo?v=33",
+        f"{SERVER_URL}/{service_ws}/services/{service_id}/echo?v=33",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert response.ok, response.json()["detail"]
@@ -206,7 +208,7 @@ async def test_http_proxy(
     assert service_info["v"] == 33
 
     response = requests.post(
-        f"{SERVER_URL}/{service_ws}/services/test_service/echo",
+        f"{SERVER_URL}/{service_ws}/services/{service_id}/echo",
         data=msgpack.dumps({"data": 123}),
         headers={"Content-type": "application/msgpack"},
     )
@@ -215,7 +217,7 @@ async def test_http_proxy(
     assert result["data"] == 123
 
     response = requests.post(
-        f"{SERVER_URL}/{service_ws}/services/test_service/echo",
+        f"{SERVER_URL}/{service_ws}/services/{service_id}/echo",
         data=json.dumps({"data": 123}),
         headers={"Content-type": "application/json"},
     )
@@ -224,7 +226,7 @@ async def test_http_proxy(
     assert result["data"] == 123
 
     response = requests.post(
-        f"{SERVER_URL}/{service_ws}/services/test_service/echo",
+        f"{SERVER_URL}/{service_ws}/services/{service_id}/echo",
         data=msgpack.dumps({"data": 123}),
         headers={
             "Content-type": "application/msgpack",
@@ -250,7 +252,7 @@ async def test_http_proxy(
     data = msgpack.dumps({"data": input_data})
     compressed_data = gzip.compress(data)
     response = requests.post(
-        f"{SERVER_URL}/{service_ws}/services/test_service/echo",
+        f"{SERVER_URL}/{service_ws}/services/{service_id}/echo",
         data=compressed_data,
         headers={
             "Content-Type": "application/msgpack",

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -82,7 +82,7 @@ async def test_http_services(minio_server, fastapi_server, test_user_token):
     def use_my_service():
         url = f"{SERVER_URL}/{workspace}/services/{svc.id.split('/')[1]}/echo"
         response = requests.post(url, json={"data": "123"})
-        assert response.status_code == 200
+        assert response.status_code == 200, f"{response.text}"
         assert response.json() == "123"
 
         response = requests.get(f"{SERVER_URL}/{workspace}/services")

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -78,19 +78,19 @@ async def test_http_services(minio_server, fastapi_server, test_user_token):
             "echo": lambda data: data,
         }
     )
-    await asyncio.sleep(0.5)
-    async with httpx.AsyncClient(timeout=20.0) as client:
+
+    def use_my_service():
         url = f"{SERVER_URL}/{workspace}/services/{svc.id.split('/')[1]}/echo"
-        data = await client.post(url, json={"data": "123"})
-        assert data.status_code == 200
-        assert data.json() == "123"
+        response = requests.post(url, json={"data": "123"})
+        assert response.status_code == 200
+        assert response.json() == "123"
 
-        data = await client.get(f"{SERVER_URL}/{workspace}/services")
-        # [{'config': {'visibility': 'public', 'require_context': False, 'workspace': 'VRRVEdTF9of2y4cLmepzBw', 'flags': []}, 'id': '5XCPAyZrW72oBzywEk2oxP:test_service', 'name': 'test_service', 'type': 'test_service', 'description': '', 'docs': {}}]
-        assert data.status_code == 200
-        assert find_item(data.json(), "name", "my_service")
+        response = requests.get(f"{SERVER_URL}/{workspace}/services")
+        assert response.status_code == 200
+        assert find_item(response.json(), "name", "my_service")
 
-    await api.disconnect()
+    loop = asyncio.get_event_loop()
+    await loop.run_in_executor(None, use_my_service)
 
 
 # pylint: disable=too-many-statements

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -191,7 +191,7 @@ async def test_http_proxy(
     )
     print(response.text)
     assert not response.ok
-    
+
     service_id = svc1.id.split("/")[-1]
 
     response = requests.get(
@@ -269,7 +269,7 @@ async def test_http_proxy(
     )
 
     assert output_array.shape == input_array.shape
-    
+
     await controller.stop(app_config.id)
-    
+
     await api.disconnect()

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -39,7 +39,7 @@ async def test_redis_store(redis_store):
     assert find_item(wss, "name", "test")
 
     api = await redis_store.connect_to_workspace("test", client_id="test-app-99")
-    clients = set(await api.list_clients())
+    clients = await api.list_clients()
     assert find_item(clients, "id", "test/test-app-99")
     await api.log("hello")
     services = await api.list_services()

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -40,7 +40,7 @@ async def test_redis_store(redis_store):
 
     api = await redis_store.connect_to_workspace("test", client_id="test-app-99")
     clients = set(await api.list_clients())
-    assert clients == {"test/test-app-99"}
+    assert find_item(clients, "id", "test/test-app-99")
     await api.log("hello")
     services = await api.list_services()
     assert len(services) == 1
@@ -73,7 +73,8 @@ async def test_redis_store(redis_store):
 
     wm = await redis_store.connect_to_workspace("test", client_id="test-app-22")
     clients = await wm.list_clients()
-    assert set(clients) == set(["test/test-app-22", "test/test-app-99"])
+    assert find_item(clients, "id", "test/test-app-22")
+    assert find_item(clients, "id", "test/test-app-99")
     rpc = wm.rpc
     services = await wm.list_services()
     service = await rpc.get_remote_service("test-app-99:test-service")
@@ -94,10 +95,8 @@ async def test_websocket_server(fastapi_server, test_user_token_2):
     )
     await wm.log("hello")
 
-    clients = set(await wm.list_clients())
-    assert clients == {
-        wm.config.workspace + "/test-app-1",
-    }
+    clients = await wm.list_clients()
+    assert find_item(clients, "id", wm.config.workspace + "/test-app-1")
     rpc = wm.rpc
 
     def echo(data):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -151,6 +151,11 @@ async def test_s3(minio_server, fastapi_server, test_user_token):
             fil.write("hello")
         await obj.upload_file("/tmp/hello.txt")
 
+        with open("/tmp/hello2.txt", "w", encoding="utf-8") as fil:
+            fil.write("hello")
+        await obj.upload_file("/tmp/hello2.txt")
+        await s3controller.delete_file("hello2.txt")
+
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, test_file_requests)
         await asyncio.sleep(0.1)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -322,10 +322,8 @@ async def test_server_scalability(
     await asyncio.sleep(0.2)
 
     clients = await api77.list_clients()
-    assert (
-        "my-test-workspace/my-app-77" in clients
-        and "my-test-workspace/my-app-88" in clients
-    )
+    assert find_item(clients, "id", "my-test-workspace/my-app-77")
+    assert find_item(clients, "id", "my-test-workspace/my-app-88")
 
     await api77.register_service(
         {

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -137,8 +137,8 @@ async def test_cleanup_workspace(fastapi_server, root_user_token):
         servers = await admin.list_servers()
         assert len(servers) == 1
         summary = await api.cleanup("public")
-        assert "removed_clients" in summary
-        assert len(summary["removed_clients"]) == 0
+        assert "removed_clients" not in summary
+        assert len(summary) == 0
 
 
 async def test_login(fastapi_server):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -104,7 +104,8 @@ async def test_workspace(fastapi_server, test_user_token):
     await api2.export({"foo": "bar"})
     # services = api2.rpc.get_all_local_services()
     clients = await api2.list_clients()
-    assert "my-new-test-workspace/my-app-2" in clients
+    assert find_item(clients, "id", "my-new-test-workspace/my-app-2")
+
     ss3 = await api2.list_services({"type": "test-type"})
     assert len(ss3) == 1
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,30 +10,12 @@ python =
   3.12: py312
 
 [testenv]
-setenv =
-  HYPHA_SERVER_ID=server-py{envpython:python_version_minor}
 commands =
   playwright install
   pytest -v --timeout=0 --cov=hypha --cov-report=xml --asyncio-mode=strict {posargs}
 deps =
   -rrequirements.txt
   -rrequirements_test.txt
-
-[testenv:py39]
-setenv =
-  HYPHA_SERVER_ID=server-py39
-
-[testenv:py310]
-setenv =
-  HYPHA_SERVER_ID=server-py310
-
-[testenv:py311]
-setenv =
-  HYPHA_SERVER_ID=server-py311
-
-[testenv:py312]
-setenv =
-  HYPHA_SERVER_ID=server-py312
 
 [testenv:lint]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -4,18 +4,36 @@ skip_missing_interpreters = True
 
 [gh-actions]
 python =
-  3.8: py38 #, lint
+  3.8: py38
   3.9: py39
   3.10: py310
   3.11: py311
 
 [testenv]
+setenv =
+  HYPHA_SERVER_ID=server-py{envpython:python_version_minor}
 commands =
   playwright install
   pytest -v --timeout=0 --cov=hypha --cov-report=xml --asyncio-mode=strict {posargs}
 deps =
   -rrequirements.txt
   -rrequirements_test.txt
+
+[testenv:py38]
+setenv =
+  HYPHA_SERVER_ID=server-py38
+
+[testenv:py39]
+setenv =
+  HYPHA_SERVER_ID=server-py39
+
+[testenv:py310]
+setenv =
+  HYPHA_SERVER_ID=server-py310
+
+[testenv:py311]
+setenv =
+  HYPHA_SERVER_ID=server-py311
 
 [testenv:lint]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-envlist = py38, py39, py310, py311, lint
+envlist = py39, py310, py311, py312, lint
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-  3.8: py38
   3.9: py39
   3.10: py310
   3.11: py311
+  3.12: py312
 
 [testenv]
 setenv =
@@ -18,10 +18,6 @@ commands =
 deps =
   -rrequirements.txt
   -rrequirements_test.txt
-
-[testenv:py38]
-setenv =
-  HYPHA_SERVER_ID=server-py38
 
 [testenv:py39]
 setenv =
@@ -34,6 +30,10 @@ setenv =
 [testenv:py311]
 setenv =
   HYPHA_SERVER_ID=server-py311
+
+[testenv:py312]
+setenv =
+  HYPHA_SERVER_ID=server-py312
 
 [testenv:lint]
 basepython = python3


### PR DESCRIPTION
This PR enhance multi-instance hypha server support by allowing passing a server id (e.g. using the pod id in a k8s cluster).

This PR also clean up old records in the redis database created by the server, it is important to fix the hypha-login issue (sometimes the last server client is left in the redis and causing a dead server client which can pick up by the login service).