### PR TITLE
Enable s3 proxy

### DIFF
--- a/docs/operate-files.md
+++ b/docs/operate-files.md
@@ -24,6 +24,8 @@ python3 -m hypha.server \
 - `--endpoint-url-public`: Public URL for accessing the files (may be the same as `--endpoint-url`).
 - `--s3-admin-type`: Specifies the S3 admin type (e.g., `minio`, `generic`). If it's a minio server (not gateway mode), use `minio`, otherwise use `generic` would be enough for most cases.
 
+If your `--endpoint-url-public` is not accessible from outside, you can enable the s3 proxy provided by hypha by adding `--enable-s3-proxy` to the command line. This will allow you to access the s3 files through the hypha server.
+
 After starting Hypha with these arguments, you can verify that the S3 service is available by visiting the following URL:
 
 ```
@@ -316,11 +318,11 @@ api = await connect_to_server({"server_url": "https://hypha.aicell.io"})
 workspace = api.config["workspace"]
 token = await api.generate_token()
 
-async def upload_file_to_hypha(server_url: str, file_path: str, token: str):
+async def upload_file_to_hypha(file_upload_url: str, file_path: str, token: str):
     async with httpx.AsyncClient() as client:
         with open(file_path, "rb") as file:
             response = await client.put(
-                server_url, headers={"Authorization": f"Bearer {token}"}, content=file
+                file_upload_url, headers={"Authorization": f"Bearer {token}"}, content=file
             )
             print(response.status_code, response.reason_phrase)
 
@@ -338,9 +340,9 @@ api = await connect_to_server({"server_url": "https://hypha.aicell.io"})
 workspace = api.config["workspace"]
 token = await api.generate_token()
 
-def upload_file_to_hypha(server_url, file_path, token):
+def upload_file_to_hypha(upload_url, file_path, token):
     with open(file_path, "rb") as file:
-        response = requests.put(server_url, headers={"Authorization": f"Bearer {token}"}, data=file)
+        response = requests.put(upload_url, headers={"Authorization": f"Bearer {token}"}, data=file)
         print(response.status_code, response.reason)
 
 # Example usage:
@@ -354,10 +356,10 @@ const api = await connectToServer({"server_url": "https://hypha.aicell.io"});
 const token = await api.generateToken();
 const workspace = api.config.workspace;
 
-async function uploadFileToHypha(fileInputId, serverUrl, token) {
-  const file = document.getElementById(fileInputId).files[0];
+async function uploadFileToHypha(file, fileUploadUrl, token) {
+  
   try {
-    const response = await axios.put(serverUrl + file.name, file, {
+    const response = await axios.put(fileUploadUrl, file, {
       headers: {
         "Authorization": `Bearer ${token}`,
         "Content-Type": "application/octet-stream"
@@ -370,7 +372,8 @@ async function uploadFileToHypha(fileInputId, serverUrl, token) {
 }
 
 // Example usage:
-// uploadFileToHypha('fileInput', `https://hypha.aicell.io/${workspace}/files/`, token);
+// const file = document.getElementById(fileInputId).files[0];
+// uploadFileToHypha(file, `https://hypha.aicell.io/${workspace}/files/${file.name}`, token);
 ```
 
 <!-- tabs:end -->

--- a/hypha/VERSION
+++ b/hypha/VERSION
@@ -1,3 +1,3 @@
 {
-    "version": "0.20.35.post4"
+    "version": "0.20.35.post5"
 }

--- a/hypha/server.py
+++ b/hypha/server.py
@@ -96,6 +96,7 @@ def start_builtin_services(
             endpoint_url_public=args.endpoint_url_public,
             region_name=args.region_name,
             s3_admin_type=args.s3_admin_type,
+            enable_s3_proxy=args.enable_s3_proxy,
             workspace_bucket=args.workspace_bucket,
             executable_path=args.executable_path,
         )
@@ -395,15 +396,19 @@ def get_argparser(add_help=True):
         "--startup-functions",
         type=str,
         nargs="*",
-        help="Specifies one or more startup functions. Each URI should be in the format '<python module or script>:<entrypoint function name>'. These functions are executed at server startup to perform initialization tasks such as loading services, configuring the server, or launching additional processes.",
+        help="specifies one or more startup functions. Each URI should be in the format '<python module or script>:<entrypoint function name>'. These functions are executed at server startup to perform initialization tasks such as loading services, configuring the server, or launching additional processes.",
     )
     parser.add_argument(
         "--server-id",
         type=str,
         default=None,
-        help="The server ID of this instance, used to distinguish between multiple instances of hypha server in a distributed environment",
+        help="the server ID of this instance, used to distinguish between multiple instances of hypha server in a distributed environment",
     )
-
+    parser.add_argument(
+        "--enable-s3-proxy",
+        action="store_true",
+        help="enable S3 proxy for serving pre-signed URLs",
+    )
     return parser
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,6 +166,7 @@ def fastapi_server_fixture(minio_server):
             f"--access-key-id={MINIO_ROOT_USER}",
             f"--secret-access-key={MINIO_ROOT_PASSWORD}",
             f"--endpoint-url-public={MINIO_SERVER_URL_PUBLIC}",
+            "--enable-s3-proxy",
             f"--workspace-bucket=my-workspaces",
             "--s3-admin-type=minio",
             f"--triton-servers=http://127.0.0.1:{TRITON_PORT}",


### PR DESCRIPTION
Some s3 server may hidden behind firewall, here we add an option to allow the s3 server to be exposed externally by passing `--enable-s3-proxy`, the presigned url will then be created as `{hypha-server-url}/s3/...`