### PR TITLE
Add docsify search scroll-to-match plugin

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -64,7 +64,25 @@
         theme: 'classic',
         tabComments: true,
         tabHeadings: true
-      }
+      },
+      plugins: [
+        function(hook, vm) {
+          hook.doneEach(function() {
+            // Scroll to the first search match if it exists
+            setTimeout(function() {
+                var mark = document.querySelector('.markdown-section mark');
+                if (mark) {
+                    // Calculate position with offset for header
+                    var top = mark.getBoundingClientRect().top + window.pageYOffset - 100;
+                    window.scrollTo({
+                        top: top,
+                        behavior: 'smooth'
+                    });
+                }
+            }, 750); // Increased delay to ensure rendering matches
+          });
+        }
+      ]
     };
   </script>
   <script src="https://imjoy-team.github.io/imjoy-docs/static/docsify-run-code.js"></script>


### PR DESCRIPTION
## Summary
- Adds a docsify plugin that auto-scrolls to the first highlighted search match with a 100px header offset
- Clean extraction of the docs changes from #849 by @hugokallander, without the unrelated artifact test changes

Supersedes #849.

## Test plan
- [ ] CI passes
- [ ] Verify search scroll behavior on docs site after deploy

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)