### PR TITLE
fix: cleanup stale client services on disconnect and server startup

### DIFF
--- a/hypha/websocket.py
+++ b/hypha/websocket.py
@@ -182,6 +182,16 @@ class WebsocketServer:
                 await self.establish_websocket_communication(
                     websocket, workspace_info.id, client_id, user_info
                 )
+                # Normal return (idle timeout or server stopping) — still need
+                # to remove the client's services from Redis.
+                await self.handle_disconnection(
+                    websocket,
+                    workspace,
+                    client_id,
+                    user_info,
+                    status.WS_1000_NORMAL_CLOSURE,
+                    None,
+                )
             except RuntimeError as exp:
                 # this happens when the websocket is closed
                 logger.error(f"RuntimeError in establish_websocket_communication: {str(exp)}")


### PR DESCRIPTION
## Summary

Fixes two bugs that cause stale built-in services to accumulate in Redis (root cause of #857):

- **Bug 1**: `establish_websocket_communication` can return normally (idle timeout or server stopping) but `handle_disconnection` was only called in `except` blocks. The client's services were never cleaned up on the normal return path.
- **Bug 2**: When a server crashes without graceful shutdown, user-connected WebSocket clients' services remain in Redis. Their random client IDs don't match the `server_id` patterns used by `check_and_cleanup_servers`, so they persist indefinitely. Added `_cleanup_orphaned_client_services()` that runs on server startup, pings each client's `built-in` service, and removes entries for unreachable clients.

### Horizontal scaling safety
The orphan cleanup pings go through the Redis event bus, so a client connected to **any** live server in the cluster will respond correctly. Only truly dead clients (not connected to any server) get cleaned up.

### Files changed
- `hypha/websocket.py` — call `handle_disconnection` on normal return from `establish_websocket_communication`
- `hypha/core/store.py` — add `_cleanup_orphaned_client_services()` method, called during `init()`
- `tests/test_server_disconnection.py` — two new tests validating both fixes

## Test plan
- [x] `test_normal_return_cleanup` — verifies services are cleaned up via `remove_client` (Bug 1 path)
- [x] `test_orphaned_client_cleanup_on_startup` — verifies orphaned user services are detected and removed on startup (Bug 2)
- [x] Existing disconnect tests pass (5 unit-level + 4 corrupted service tests)
- [x] Docker-free test suite passes (88 tests)
- [ ] CI pipeline

Closes #857

🤖 Generated with [Claude Code](https://claude.ai/code)