### PR TITLE
fix: clean up ghost _last_seen entries in idle cleanup loop

### DIFF
--- a/hypha/websocket.py
+++ b/hypha/websocket.py
@@ -645,6 +645,12 @@ class WebsocketServer:
                 except Exception as e:
                     logger.debug("Error disconnecting idle WebSocket %s: %s", key, e)
                     self._last_seen.pop(key, None)
+            else:
+                # Ghost entry: in _last_seen but no active WebSocket — clean it up.
+                # This can happen when a reconnection race leaves _last_seen populated
+                # but the WebSocket was already removed from _websockets.
+                logger.debug("Removing ghost _last_seen entry for %s (no active WebSocket)", key)
+                self._last_seen.pop(key, None)
 
     async def _idle_cleanup_loop(self):
         """Periodically disconnect idle connections (prevents explosion without strict rate limiting)."""

--- a/tests/test_websocket_idle_toctou.py
+++ b/tests/test_websocket_idle_toctou.py
@@ -121,7 +121,7 @@ async def test_toctou_connection_becomes_active_during_cleanup():
 
 
 async def test_already_removed_connection_skipped():
-    """If a websocket is removed from _websockets before cleanup reaches it, skip it gracefully."""
+    """Ghost _last_seen entry (no active WebSocket) is cleaned up without calling disconnect()."""
     server = _make_server(idle_timeout=60)
     now = time.time()
 
@@ -139,6 +139,7 @@ async def test_already_removed_connection_skipped():
     await server._do_idle_cleanup()
 
     assert disconnected == [], "No disconnect should be called for already-removed connection"
+    assert key not in server._last_seen, "Ghost _last_seen entry must be removed by idle cleanup"
 
 
 async def test_multiple_stale_connections_all_disconnected():


### PR DESCRIPTION
## Summary

- Ghost entries in `_last_seen` (clients in `_last_seen` but not in `_websockets`) were silently skipped and accumulated indefinitely in `_do_idle_cleanup()`
- Root cause: reconnection race where the old handler saw `is_current=False` and skipped cleanup, but the new connection subsequently disconnected — leaving a stale `_last_seen` timestamp
- Fix: add an `else` branch to remove ghost entries immediately when the idle timeout has elapsed (no `disconnect()` call needed — there's no WS to close)
- Observed live: `ws-user-github|478667/r0u78ukody` persisted in `_last_seen` for 9+ hours with no active WebSocket

## Test plan
- [ ] `tests/test_websocket_idle_toctou.py::test_already_removed_connection_skipped` now asserts the ghost entry is removed (not just that no disconnect is called)

🤖 Generated with [Claude Code](https://claude.com/claude-code)