### PR TITLE
fix: propagate worker_id from install() through commit_app() to start()

### DIFF
--- a/hypha/apps.py
+++ b/hypha/apps.py
@@ -1824,6 +1824,7 @@ class ServerAppController:
                     version=version,
                     context=context,
                     progress_callback=progress_callback,
+                    worker_id=worker_id,
                     **startup_config_kwargs,
                 )
                 # After commit, read the updated artifact to get the collected services
@@ -1953,6 +1954,10 @@ class ServerAppController:
             None,
             description="Callback function to receive progress updates from the app.",
         ),
+        worker_id: Optional[str] = Field(
+            None,
+            description="Specific worker ID to use for starting the verification run. If provided, the worker type must match the app type. If not provided, a worker will be selected automatically within the current workspace.",
+        ),
         context: Optional[dict] = Field(
             None,
             description="Additional context information including user and workspace details. Usually provided automatically by the system.",
@@ -1997,7 +2002,7 @@ class ServerAppController:
                 start_config["progress_callback"] = progress_callback
 
             info = await self.start(
-                app_id, version="stage", stage=True, context=context, **start_config
+                app_id, version="stage", stage=True, context=context, worker_id=worker_id, **start_config
             )
             await self.stop(info["id"], context=context)
 


### PR DESCRIPTION
## Summary

Fixes #922

- `install(worker_id=...)` used the provided worker for compilation but dropped `worker_id` when calling `commit_app()` for the verification run
- `commit_app()` then fell back to `get_server_app_workers()` which only searches the caller's workspace and the public workspace — ignoring the explicitly-specified cross-workspace worker
- Added `worker_id` parameter to `commit_app()` and threaded it through to `start()`, which already handles cross-workspace worker IDs correctly

## Root cause

```
install(worker_id="hypha-agents/hypha-compute-worker:foo")
  → uses worker for compile ✓
  → commit_app(app_id, ...)      # worker_id NOT passed ← BUG
      → start(app_id, ...)       # no worker_id
          → get_server_app_workers(app_type, context)  # only searches caller ws + public
          → "No server app worker found"               # failure
```

## Fix

Thread `worker_id` from `install()` → `commit_app()` → `start()`. Six lines changed.

## Test plan

- [ ] Existing `test_server_apps.py` tests still pass
- [ ] Manually verify cross-workspace worker install no longer fails with "No server app worker found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)