### PR TITLE
fix: delete null session metadata fields from Redis instead of silently ignoring them

### DIFF
--- a/hypha/apps.py
+++ b/hypha/apps.py
@@ -551,22 +551,31 @@ class ServerAppController:
         """Store session data in Redis."""
         try:
             key = f"sessions:{full_client_id}"
-            # Store session metadata in Redis (excluding worker instance and None values)
+            # Store session metadata in Redis (excluding internal _-prefixed fields)
             redis_data = {}
+            null_keys = []  # Keys explicitly set to None — remove from Redis hash
             for k, v in session_data.items():
-                if not k.startswith("_") and v is not None:
-                    # Use key prefixes to indicate data type for explicit deserialization
-                    if isinstance(v, list):
-                        redis_data[f"json_list:{k}"] = json.dumps(v)
-                    elif isinstance(v, dict):
-                        redis_data[f"json_dict:{k}"] = json.dumps(v)
-                    elif isinstance(v, bool):
-                        redis_data[k] = int(v)  # Redis doesn't accept bool
-                    elif isinstance(v, (str, bytes, int, float)):
-                        redis_data[k] = v
-                    else:
-                        redis_data[k] = str(v)
-            await self._redis.hset(key, mapping=redis_data)
+                if k.startswith("_"):
+                    continue
+                if v is None:
+                    null_keys.append(k)
+                    continue
+                # Use key prefixes to indicate data type for explicit deserialization
+                if isinstance(v, list):
+                    redis_data[f"json_list:{k}"] = json.dumps(v)
+                elif isinstance(v, dict):
+                    redis_data[f"json_dict:{k}"] = json.dumps(v)
+                elif isinstance(v, bool):
+                    redis_data[k] = int(v)  # Redis doesn't accept bool
+                elif isinstance(v, (str, bytes, int, float)):
+                    redis_data[k] = v
+                else:
+                    redis_data[k] = str(v)
+            if redis_data:
+                await self._redis.hset(key, mapping=redis_data)
+            # Explicitly delete keys set to None so stale values don't persist
+            if null_keys:
+                await self._redis.hdel(key, *null_keys)
             
             # Cache worker instance locally by worker_id
             if "_worker" in session_data and "worker_id" in session_data:

--- a/tests/test_session_null_metadata.py
+++ b/tests/test_session_null_metadata.py
@@ -1,0 +1,114 @@
+"""Tests for null value handling in _store_session_in_redis.
+
+Reproduces the bug where setting a session field to None would leave the old
+value in Redis (because the old code silently skipped None values instead of
+explicitly deleting the hash field).
+"""
+
+import pytest
+from fakeredis.aioredis import FakeRedis
+from hypha.apps import ServerAppController
+
+
+class MinimalController:
+    """Minimal stand-in for ServerAppController with only Redis and cache."""
+
+    def __init__(self, redis):
+        self._redis = redis
+        self._worker_cache = {}
+
+    _store_session_in_redis = ServerAppController._store_session_in_redis
+    _get_session_from_redis = ServerAppController._get_session_from_redis
+    _scan_keys = ServerAppController._scan_keys
+
+
+@pytest.mark.asyncio
+async def test_null_field_deletes_stale_redis_value():
+    """Setting a session field to None must remove it from Redis.
+
+    Regression test for the bug where None values were silently skipped,
+    causing old values to persist in Redis across updates.
+    """
+    redis = FakeRedis()
+    c = MinimalController(redis)
+
+    # First store: description has a value
+    await c._store_session_in_redis("ws/client-1", {
+        "status": "running",
+        "description": "initial description",
+        "worker_id": "worker-abc",
+    })
+
+    # Verify initial value is stored
+    session = await c._get_session_from_redis("ws/client-1")
+    assert session is not None
+    assert session["description"] == "initial description"
+    assert session["worker_id"] == "worker-abc"
+
+    # Second store: description cleared to None
+    await c._store_session_in_redis("ws/client-1", {
+        "status": "running",
+        "description": None,   # <-- explicitly cleared
+        "worker_id": "worker-abc",
+    })
+
+    # After fix: description field must be gone from Redis (not stale old value)
+    session = await c._get_session_from_redis("ws/client-1")
+    assert session is not None
+    assert "description" not in session, (
+        f"description should have been deleted from Redis when set to None, "
+        f"but got: {session.get('description')!r}"
+    )
+    # Other fields must survive
+    assert session["status"] == "running"
+    assert session["worker_id"] == "worker-abc"
+
+
+@pytest.mark.asyncio
+async def test_internal_fields_skipped():
+    """Fields starting with '_' must never be written to Redis."""
+    redis = FakeRedis()
+    c = MinimalController(redis)
+
+    await c._store_session_in_redis("ws/client-2", {
+        "status": "running",
+        "_worker": object(),   # internal: should be skipped
+        "_private": "secret",  # internal: should be skipped
+        "worker_id": "worker-xyz",
+    })
+
+    raw = await redis.hgetall("sessions:ws/client-2")
+    keys = {k.decode() if isinstance(k, bytes) else k for k in raw}
+    assert "_worker" not in keys
+    assert "_private" not in keys
+    assert "worker_id" in keys
+
+
+@pytest.mark.asyncio
+async def test_multiple_null_fields_all_deleted():
+    """Multiple None fields in a single update must all be deleted."""
+    redis = FakeRedis()
+    c = MinimalController(redis)
+
+    # Store initial values
+    await c._store_session_in_redis("ws/client-3", {
+        "name": "My App",
+        "description": "A description",
+        "docs": "Some docs",
+        "status": "running",
+    })
+
+    # Clear multiple fields at once
+    await c._store_session_in_redis("ws/client-3", {
+        "name": "My App",
+        "description": None,
+        "docs": None,
+        "status": "stopped",
+    })
+
+    session = await c._get_session_from_redis("ws/client-3")
+    assert session is not None
+    assert "description" not in session
+    assert "docs" not in session
+    assert session["name"] == "My App"
+    assert session["status"] == "stopped"


### PR DESCRIPTION
## Summary
- Fixes `_store_session_in_redis()` in `hypha/apps.py` to correctly handle `None` values
- Previously, keys with `None` values were silently skipped, causing old values to persist in Redis
- Fix: explicitly `hdel` null-keyed fields after `hset`, so they are removed from the hash
- Also adds `if redis_data:` guard before `hset` to avoid empty-mapping calls

## Root cause
When updating session metadata, if a caller set a field to `None` to "clear" it, the previous Redis value for that key persisted indefinitely because the write loop used `if v is not None: ...` and simply skipped None values.

Example:
```
# Session in Redis: {status: "running", extra: "bar"}
# Caller sets: {status: "done", extra: None}  (intending to clear `extra`)
# Before fix: Redis still has {status: "done", extra: "bar"}  ← stale!
# After fix:  Redis has {status: "done"}  ← extra removed
```

## Test plan
- [ ] Verify session update with a null field clears the old value from Redis
- [ ] Verify existing session metadata (non-null fields) still work correctly
- [ ] Verify no regressions in session lifecycle (start/stop/update)

Closes #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)