### PR TITLE
fix: remove limit_max_requests from uvicorn to prevent liveness probe failures

### DIFF
--- a/hypha/server.py
+++ b/hypha/server.py
@@ -797,8 +797,6 @@ if __name__ == "__main__":
             port=int(opt.port),
             # Enable HTTP/1.1 keep-alive for connection reuse
             timeout_keep_alive=300,  # Match client keep-alive (5 minutes)
-            # Limit max request body size for security
-            limit_max_requests=10000,  # Restart worker after 10k requests (prevents memory leaks)
             # Enable access log only if needed (disable for production performance)
             access_log=os.environ.get("HYPHA_ACCESS_LOG", "false").lower() == "true",
             # Disable uvicorn's WebSocket protocol-level ping to prevent


### PR DESCRIPTION
## Summary

- Removes `limit_max_requests=10000` from `uvicorn.run()` in `hypha/server.py`

## Root Cause

`limit_max_requests=10000` causes uvicorn to restart the worker process after
10,000 HTTP requests. During reconnection storms (e.g., after a server upgrade
with 100+ clients reconnecting simultaneously), this limit can be hit in ~12
minutes. When uvicorn respawns the worker, there is a brief window where it
stops accepting TCP connections.

This triggered:
- **Liveness probe failure** (`connection refused` on `/health/liveness`) after ~12 min uptime
- **Pod killed and restarted** (observed 2026-03-07 06:05 UTC on 0.21.75 deployment)
- **Cascading restarts**: bioengine-worker (13→17 restarts) and hypha-weaviate (10→12) because their liveness probes call external Hypha HTTPS and failed during the server's brief downtime

## Why This Fix Is Safe

The original comment said "prevents memory leaks" but Hypha now has proper
memory management via:
- Disconnect handler correctly cleans up `_object_store` entries (PR #920)
- Redis SCAN instead of KEYS prevents blocking (PR #921)
- GC abuse removed (PR #920)
- Ghost `_last_seen` entry cleanup (PR #925)
- Heartbeat task leak fixed in hypha-rpc 0.21.33 (PR #924)

Periodic uvicorn worker respawns are unnecessary and harmful for a stateful
long-running server like Hypha.

## Test Plan

- [x] CI: Python 3.10, 3.11, 3.12 test suite
- [x] Verified fix at server.py:794-810 removes only the problematic setting
- [x] Server behavior unchanged — only difference is no worker restart after 10k requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)