### PR TITLE
fix: prevent reconnection race in handle_disconnection

### DIFF
--- a/hypha/websocket.py
+++ b/hypha/websocket.py
@@ -412,6 +412,8 @@ class WebsocketServer:
         gen = self._ws_generation.get(conn_key, 0) + 1
         self._ws_generation[conn_key] = gen
         self._websockets[conn_key] = websocket
+        # Tag websocket with its generation for use in handle_disconnection
+        websocket._ws_gen = gen
         self._last_seen[conn_key] = time.time()
         rate_limiter = TokenBucketRateLimiter(self._msg_rate_limit, self._msg_burst_limit)
         try:
@@ -580,12 +582,16 @@ class WebsocketServer:
         avoid deleting the new connection's services.
         """
         conn_key = f"{workspace}/{client_id}"
-        current_ws = self._websockets.get(conn_key)
-        if current_ws is not None and current_ws is not websocket:
+        # Use generation counter to detect if a newer connection has taken over.
+        # Each new connection bumps the generation and tags it on the websocket.
+        # If our generation doesn't match the current one, a reconnection happened.
+        my_gen = getattr(websocket, "_ws_gen", 0)
+        current_gen = self._ws_generation.get(conn_key, 0)
+        if my_gen < current_gen:
             # A newer connection has taken over — do NOT remove services
             logger.info(
-                "Skipping remove_client for %s: superseded by a newer connection",
-                conn_key,
+                "Skipping remove_client for %s: superseded by newer connection (gen %s < %s)",
+                conn_key, my_gen, current_gen,
             )
             # Still close this old websocket gracefully
             await self.disconnect(
@@ -599,6 +605,15 @@ class WebsocketServer:
         self.store._event_bus.track_recently_disconnected(workspace, client_id)
         cleanup_succeeded = False
         try:
+            # Re-check generation right before the destructive remove_client.
+            # A reconnecting client may have bumped the generation while we
+            # were doing earlier async work (event tracking, etc.).
+            if self._ws_generation.get(conn_key, 0) > my_gen:
+                logger.info(
+                    "Skipping remove_client for %s: new connection during cleanup (gen %s -> %s)",
+                    conn_key, my_gen, self._ws_generation.get(conn_key, 0),
+                )
+                return
             await self.store.remove_client(client_id, workspace, user_info, unload=True)
             cleanup_succeeded = True
             if code in [status.WS_1000_NORMAL_CLOSURE, status.WS_1001_GOING_AWAY]:


### PR DESCRIPTION
## Summary
- Fix race condition where `handle_disconnection`'s `remove_client` deletes a reconnected client's services
- Replace websocket identity check with generation counter comparison
- Add double-check before `remove_client` to catch reconnections during async cleanup

## Root cause
When multiple clients reconnect simultaneously (e.g. after server restart), the old connection's `handle_disconnection` can race with the new connection:

1. Old connection closes → `handle_disconnection` called
2. Previous check: `current_ws is not websocket` — passes because `_websockets[conn_key]` still holds the OLD websocket
3. Client reconnects → new connection bumps generation, registers services
4. `remove_client` (async) executes → **deletes the new connection's services**
5. Client thinks it's connected but server has no services registered

This manifests as flaky `test_multiple_clients_reconnection` (2/3 clients succeed, 1 fails with "Connection has already been closed").

## Fix
- Tag each websocket with its generation counter (`_ws_gen`) at connection time
- `handle_disconnection` compares `websocket._ws_gen` against current `_ws_generation[conn_key]`
- If stale (my_gen < current_gen): skip `remove_client`
- Re-check right before `remove_client` to catch reconnections during earlier async work

## Test plan
- [x] `test_multiple_clients_reconnection` should pass reliably
- [ ] Manual test: rapid reconnection doesn't lose services

🤖 Generated with [Claude Code](https://claude.com/claude-code)