### PR TITLE
feat: allow admins to override email claim in generate_token

### DIFF
--- a/hypha/core/__init__.py
+++ b/hypha/core/__init__.py
@@ -616,6 +616,15 @@ class TokenConfig(BaseModel):
         None,
         description="Optional client ID to restrict the token to a specific client",
     )
+    email: Optional[EmailStr] = Field(
+        None,
+        description=(
+            "Override the email claim on the generated token. Only callers "
+            "with the 'admin' role may set this — it lets operators mint "
+            "user-attributed tokens for downstream services (e.g. quota-"
+            "enforcing LLM gateways) that require an email claim."
+        ),
+    )
 
     @field_validator("extra_scopes")
     @classmethod

--- a/hypha/core/workspace.py
+++ b/hypha/core/workspace.py
@@ -1265,6 +1265,16 @@ class WorkspaceManager:
             client_id=config.client_id,
             extra_scopes=extra_scopes,
         )
+        # Email override: admins may mint user-attributed tokens (e.g. to
+        # satisfy downstream services that require an email claim for quota
+        # attribution). Restricted to callers with the 'admin' role so a
+        # workspace admin cannot forge emails for another user.
+        if config.email is not None:
+            if "admin" not in (user_info.roles or []):
+                raise PermissionError(
+                    "Only callers with the 'admin' role may set TokenConfig.email"
+                )
+            user_info.email = config.email
         config.expires_in = config.expires_in or 3600
         token = await generate_auth_token(user_info, config.expires_in)
         return token

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -283,6 +283,32 @@ def generate_authenticated_user_2():
     yield from _generate_token("user-2", [])
 
 
+@pytest_asyncio.fixture(name="admin_role_user_token", scope="session")
+def generate_admin_role_user_token():
+    """Generate a token for a user carrying the 'admin' role (superadmin).
+
+    Includes ``*: admin`` workspace scope so the user passes per-workspace
+    permission checks in addition to carrying the ``admin`` role tag.
+    """
+    auth.JWT_SECRET = JWT_SECRET
+    user_info = UserInfo(
+        id="admin-role-user",
+        is_anonymous=False,
+        email="admin-role-user@test.com",
+        parent=None,
+        roles=["admin"],
+        scope=create_scope(workspaces={"*": UserPermission.admin}),
+        expires_at=None,
+    )
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        token = loop.run_until_complete(generate_auth_token(user_info, 18000))
+        yield token
+    finally:
+        loop.close()
+
+
 @pytest_asyncio.fixture(name="test_user_token_temporary", scope="session")
 def generate_authenticated_user_temporary():
     """Generate a temporary test user token."""

--- a/tests/test_workspace_loader.py
+++ b/tests/test_workspace_loader.py
@@ -1,5 +1,8 @@
 """Test workspace loader."""
 
+import base64
+import json
+
 import pytest
 from hypha_rpc import connect_to_server
 
@@ -7,6 +10,13 @@ from . import (
     WS_SERVER_URL,
     find_item,
 )
+
+
+def _decode_jwt_claims(token):
+    """Decode JWT payload without signature verification (tests only)."""
+    payload = token.split(".")[1]
+    payload += "=" * (-len(payload) % 4)
+    return json.loads(base64.urlsafe_b64decode(payload))
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -82,3 +92,55 @@ async def test_delete_workspace(fastapi_server, test_user_token):
         # workspace will only be deleted after some time
         # workspaces = await api.list_workspaces()
         # assert not find_item(workspaces, "name", ws.id)
+
+
+async def test_generate_token_email_override_admin(
+    fastapi_server, admin_role_user_token
+):
+    """Admins may mint user-attributed tokens by supplying ``email``.
+
+    This unlocks downstream services (e.g. quota-enforcing LLM gateways)
+    that require an email claim for attribution but are reached through
+    operator-minted tokens that would otherwise carry a null email.
+    """
+    async with connect_to_server(
+        {
+            "name": "admin-app",
+            "server_url": WS_SERVER_URL,
+            "client_id": "admin-app",
+            "token": admin_role_user_token,
+        }
+    ) as api:
+        minted = await api.generate_token(
+            {
+                "workspace": "ws-user-admin-role-user",
+                "expires_in": 3600,
+                "email": "attributed-user@example.com",
+            }
+        )
+        claims = _decode_jwt_claims(minted)
+        assert claims["https://amun.ai/email"] == "attributed-user@example.com"
+
+
+async def test_generate_token_email_override_non_admin_rejected(
+    fastapi_server, test_user_token
+):
+    """Non-admin callers must NOT be able to forge ``email`` on tokens."""
+    async with connect_to_server(
+        {
+            "name": "regular-app",
+            "server_url": WS_SERVER_URL,
+            "client_id": "regular-app",
+            "token": test_user_token,
+        }
+    ) as api:
+        with pytest.raises(Exception) as exc_info:
+            await api.generate_token(
+                {
+                    "workspace": "ws-user-user-1",
+                    "expires_in": 3600,
+                    "email": "forged@example.com",
+                }
+            )
+        # Error may surface as PermissionError via RPC — check message
+        assert "admin" in str(exc_info.value).lower()


### PR DESCRIPTION
## Summary
- Adds optional `email` field to `TokenConfig`
- `generate_token` writes the override onto the newly-minted JWT's email claim
- Restricted to callers carrying the `admin` role so workspace admins can't forge emails for other users

## Why
Downstream services that validate email on incoming tokens (e.g. quota-enforcing LLM gateways like `proxy.hypha.aicell.io`) currently reject operator-minted machine tokens because admin `generate_token` calls produce tokens with `email: null`.

Concrete case: the `svamp-provisioner` mints long-lived tokens via admin credentials to hand to cloud daemons, which then use them as `ANTHROPIC_API_KEY` to reach the Hypha LLM proxy. Today the proxy returns `403 "Token must have a valid email. Re-generate your token after logging in."` because the admin-minted token has no email claim. The operator knows the user's email (it's on the session's `startup_context`), so letting admin pass it through at mint time is the cleanest fix.

## Changes
- `hypha/core/__init__.py`: add `email: Optional[EmailStr]` to `TokenConfig` (uses already-imported `EmailStr`, so pydantic validates format)
- `hypha/core/workspace.py`: in `generate_token`, when `config.email` is set, require `"admin" in user_info.roles` and set `user_info.email` before signing
- `tests/conftest.py`: add `admin_role_user_token` fixture (admin role + `*: admin` scope)
- `tests/test_workspace_loader.py`: two integration tests — admin can set email, non-admin is rejected

## Test plan
- [ ] `pytest tests/test_workspace_loader.py::test_generate_token_email_override_admin`
- [ ] `pytest tests/test_workspace_loader.py::test_generate_token_email_override_non_admin_rejected`
- [ ] Confirm existing `tests/test_workspace_loader.py::test_loading_workspace` still passes (no regression)
- [ ] Try TokenConfig validation: reject invalid email strings (pydantic `EmailStr`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)