### PR TITLE
fix(s3): handle AccessDenied on CreateBucket when bucket already exists

### DIFF
--- a/hypha/s3.py
+++ b/hypha/s3.py
@@ -229,7 +229,22 @@ class S3Controller:
                     time.sleep(retry_delay)
                     retry_delay = min(retry_delay * 1.5, 5)  # Exponential backoff up to 5 seconds
                 else:
-                    # Other error or max retries reached
+                    # Some S3-compatible providers (notably GCS with scoped HMAC
+                    # keys) return AccessDenied on CreateBucket even when the
+                    # bucket already exists and the key can read/write to it.
+                    # Verify via HeadBucket before giving up.
+                    try:
+                        s3client.head_bucket(Bucket=self.workspace_bucket)
+                        logger.warning(
+                            "CreateBucket for %r failed with %s, but HeadBucket "
+                            "succeeded; assuming bucket exists and proceeding.",
+                            self.workspace_bucket,
+                            error_code,
+                        )
+                        break
+                    except botocore.exceptions.ClientError:
+                        # Bucket is not reachable — re-raise the original error
+                        pass
                     raise
 
         # Apply CORS policy if not using MinIO


### PR DESCRIPTION
## Summary

- Some S3-compatible providers (notably GCS with scoped HMAC keys) return `AccessDenied` on `CreateBucket` even when the bucket already exists and the key can read/write to it. This crashes Hypha on startup.
- Before giving up on an unexpected `CreateBucket` error, try `HeadBucket`; if the bucket is reachable, continue. Otherwise re-raise the original error so genuine misconfigurations remain visible.

## Context — real incident this fixes

A 0.21.82 rollout on our production GKE cluster crash-looped for **14 days with 3974 restarts** because `CreateBucket` returned `AccessDenied`:

```
File "/home/hypha/s3.py", line 217, in __init__
    s3client.create_bucket(Bucket=self.workspace_bucket)
...
botocore.exceptions.ClientError: An error occurred (AccessDenied)
    when calling the CreateBucket operation: Access denied.
```

The existing branch (added in #855) handles `BucketNameUnavailable`, but on our key GCS started returning `AccessDenied` instead — same bucket, same key, accessible via `head_bucket`. `hypha/s3vector.py:990-993` already follows a HeadBucket-first pattern; this change brings `S3Controller.__init__` in line.

## Test plan

- [ ] Existing CI / s3 tests still pass (MinIO path: SlowDownWrite retry still works, success path unchanged)
- [ ] Manual: point a hypha instance at GCS with an HMAC key that has object RW but not `storage.buckets.create` against a pre-existing bucket — server should start and log a warning instead of crashing
- [ ] Manual: point at a bogus bucket with no perms — server should fail loudly with the original `AccessDenied` (re-raised), preserving the ability to surface real misconfigurations