### PR TITLE
fix(http): defer workspace permission check for public services (#952)

### DIFF
--- a/hypha/http.py
+++ b/hypha/http.py
@@ -1249,23 +1249,26 @@ class HTTPProxy:
                     # controls access to individual services, and the public
                     # workspace exists to host publicly accessible services.
                     if workspace != "public":
+                        # Probe the user's permission on the URL workspace.
+                        # If granted, run the request in that workspace's
+                        # context. If not, defer to the per-service visibility
+                        # check inside the workspace manager: public services
+                        # remain reachable; protected services raise
+                        # PermissionError -> 403 below. (Issue #952: a
+                        # signed-in browser cookie must not block access to a
+                        # public service URL in an unowned workspace.)
+                        original_scope = user_info.scope
                         user_info.scope = update_user_scope(
                             user_info, workspace_info
                         )
-                        if not user_info.check_permission(
+                        if user_info.check_permission(
                             workspace, UserPermission.read
                         ):
-                            return JSONResponse(
-                                status_code=403,
-                                content={
-                                    "success": False,
-                                    "detail": (
-                                        f"Permission denied for workspace"
-                                        f" '{workspace}'"
-                                    ),
-                                },
-                            )
-                    target_workspace = workspace
+                            target_workspace = workspace
+                        else:
+                            user_info.scope = original_scope
+                    else:
+                        target_workspace = workspace
 
                 async with self.store.get_workspace_interface(
                     user_info, target_workspace

--- a/tests/test_http_cross_workspace.py
+++ b/tests/test_http_cross_workspace.py
@@ -456,6 +456,114 @@ async def test_workspace_scoped_token_same_workspace_works(
     await api.disconnect()
 
 
+async def test_generic_token_public_service_in_unowned_workspace(
+    minio_server, fastapi_server, test_user_token
+):
+    """Regression test for issue #952.
+
+    A signed-in user (generic token, e.g. Auth0 cookie) hitting a PUBLIC
+    service URL in a workspace they have no permission for must NOT receive
+    a workspace-level 403. Service visibility (public) must grant access
+    just as it does for anonymous (no-token) callers.
+
+    Before the fix, the HTTP route enforced workspace-level read permission
+    before resolving the service, so a signed-in browser cookie caused a
+    workspace-level 403 even when the requested service was public.
+    """
+    loop = asyncio.get_event_loop()
+
+    # User-1 owns a workspace and registers BOTH a public and a protected
+    # service in it.
+    api = await connect_to_server(
+        {
+            "name": "owner",
+            "server_url": WS_SERVER_URL,
+            "token": test_user_token,
+        }
+    )
+    target_ws = await api.create_workspace(
+        {
+            "name": "public-cross-ws-952",
+            "description": "Issue 952 regression",
+        }
+    )
+    target_ws_name = target_ws["id"] if isinstance(target_ws, dict) else target_ws
+
+    api2 = await connect_to_server(
+        {
+            "name": "svc-provider",
+            "server_url": WS_SERVER_URL,
+            "token": test_user_token,
+            "workspace": target_ws_name,
+        }
+    )
+    public_svc = await api2.register_service(
+        {
+            "id": "public-issue-952",
+            "name": "public-issue-952",
+            "config": {"visibility": "public"},
+            "echo": lambda data: data,
+        }
+    )
+    public_id = public_svc["id"].split("/")[-1]
+
+    protected_svc = await api2.register_service(
+        {
+            "id": "protected-issue-952",
+            "name": "protected-issue-952",
+            "config": {"visibility": "protected"},
+            "echo": lambda data: data,
+        }
+    )
+    protected_id = protected_svc["id"].split("/")[-1]
+
+    # User-2 holds a generic token (no wid:, simulates an Auth0 cookie) with
+    # NO permission on user-1's workspace.
+    generic_token_user2 = await _generate_generic_token("user-2-952")
+
+    # 1. Public service via Authorization header — must succeed (200).
+    url_pub = f"{SERVER_URL}/{target_ws_name}/services/{public_id}/echo"
+    response = await loop.run_in_executor(
+        None,
+        lambda: _http_post(url_pub, {"data": "auth-header"}, token=generic_token_user2),
+    )
+    assert response.status_code == 200, (
+        f"Public service must be reachable with a generic token. "
+        f"Got {response.status_code}: {response.text}"
+    )
+    assert response.json() == "auth-header"
+
+    # 2. Public service via cookie (the actual issue #952 scenario).
+    response = await loop.run_in_executor(
+        None,
+        lambda: _http_post(
+            url_pub, {"data": "cookie-auth"}, cookie_token=generic_token_user2
+        ),
+    )
+    assert response.status_code == 200, (
+        f"Public service must be reachable with a session cookie. "
+        f"Got {response.status_code}: {response.text}"
+    )
+    assert response.json() == "cookie-auth"
+
+    # 3. Protected service must still 403 — the deferred check must not
+    #    accidentally widen access to protected services.
+    url_prot = f"{SERVER_URL}/{target_ws_name}/services/{protected_id}/echo"
+    response = await loop.run_in_executor(
+        None,
+        lambda: _http_post(
+            url_prot, {"data": "should-fail"}, token=generic_token_user2
+        ),
+    )
+    assert response.status_code == 403, (
+        f"Protected service in unowned workspace must remain forbidden. "
+        f"Got {response.status_code}: {response.text}"
+    )
+
+    await api2.disconnect()
+    await api.disconnect()
+
+
 async def test_anonymous_user_public_service_cross_workspace(
     minio_server, fastapi_server, test_user_token
 ):


### PR DESCRIPTION
## Summary

- Closes #952. A signed-in browser sending its `access_token` cookie to a **public** service URL in an unowned workspace was getting a workspace-level **403** before the per-service visibility check ran. Anonymous (no-cookie) requests to the same URL worked.
- Defers the workspace-level permission probe in `hypha/http.py::service_function`: workspace permission still grants the request the URL workspace as its target; if the user lacks permission, we keep their own workspace context and let the workspace-manager's `get_service_info` enforce visibility (public → allowed, protected → `PermissionError` → 403).
- Adds a regression test covering both `Authorization: Bearer` and `access_token` cookie auth paths and reasserts that protected cross-workspace access still 403s.

## Why this is safe

- Protected services in workspaces the user has no permission for still surface as `403` — the existing `get_service_info` path raises `PermissionError` for non-public services without workspace read.
- Workspace-scoped tokens (`workspace_from_token=True`) are unaffected — the changed branch only handles generic tokens hitting a different workspace via the URL.
- The `else` branch (workspace == "public") is unchanged.
- All existing security tests in `test_http_cross_workspace.py` (9), `test_security_vulnerabilities.py` (32), `test_http.py` (5), `test_http_rpc.py` (24), `test_register_auth_service.py` (4), `test_auth.py` (53), and `test_unified_auth_integration.py` (2) still pass.

## Test plan

- [x] `pytest tests/test_http_cross_workspace.py` — all 9 pass, including the new `test_generic_token_public_service_in_unowned_workspace`
- [x] `pytest tests/test_security_vulnerabilities.py tests/test_http_anonymous_cleanup.py` — 33 passed, 1 skipped
- [x] `pytest tests/test_http.py tests/test_http_rpc.py tests/test_register_auth_service.py` — 33 passed
- [x] `pytest tests/test_auth.py tests/test_unified_auth_integration.py` — 59 passed
- [ ] CI green on full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)