### PR TITLE
docs(agent-skills): add login guide and audit guide cross-links

### DIFF
--- a/docs/login.md
+++ b/docs/login.md
@@ -1,0 +1,167 @@
+# Login and Token Acquisition
+
+This guide explains how clients obtain authentication tokens for a Hypha server.
+Hypha tokens authorize all RPC and HTTP calls — once you have a token, pass it via
+`connect_to_server({..., "token": token})` or the `Authorization: Bearer <token>` HTTP
+header.
+
+There are three ways to get a token:
+
+1. **Interactive browser login** — `login()` opens an OAuth flow (Auth0 by default).
+2. **Programmatic token generation** — `server.generate_token(...)` after you're already connected as an admin.
+3. **Pre-shared token** — paste a long-lived token into configuration (e.g. `HYPHA_TOKEN` env var).
+
+Most AI agent deployments use option 2 or 3. Option 1 is for human users and for
+CLI tools that need to bootstrap a token on a new machine.
+
+## Interactive Browser Login — Python
+
+`hypha_rpc.login(config)` connects to the `public/hypha-login` service, starts an
+OAuth session, prints a URL for the user to open, then polls until the user
+completes the flow and returns a token.
+
+```python
+from hypha_rpc import login, connect_to_server
+
+# Default flow: prints the URL to stdout and waits
+token = await login({
+    "server_url": "https://hypha.aicell.io",
+    # Optional:
+    # "workspace": "ws-user-xyz",     # request a token scoped to a workspace
+    # "expires_in": 3600 * 24 * 30,   # seconds; default is server-configured
+    # "login_timeout": 180,           # how long to wait for user to finish
+    # "profile": True,                # return {"token": ..., "user": {...}}
+})
+
+async with connect_to_server({
+    "server_url": "https://hypha.aicell.io",
+    "token": token,
+}) as server:
+    print(await server.check_status())
+```
+
+### Custom `login_callback`
+
+By default `login()` prints the login URL. In a GUI app, notebook, bot, or
+headless environment, provide a `login_callback` to display the URL however you
+like. The callback receives a dict with `login_url`, `key`, and `report_url`:
+
+```python
+async def my_callback(context):
+    # context = {"login_url": "https://...", "key": "...", "report_url": "..."}
+    print("Open this link to sign in:", context["login_url"])
+    # e.g. send to Slack, render a QR code, open a webview, etc.
+    # await bot.send_message(chat_id, context["login_url"])
+
+token = await login({
+    "server_url": "https://hypha.aicell.io",
+    "login_callback": my_callback,
+    "login_timeout": 300,
+})
+```
+
+The callback may be `async` or sync. `login()` returns only after the user
+finishes the browser flow or the timeout elapses.
+
+### Logout
+
+```python
+from hypha_rpc import logout
+
+await logout({"server_url": "https://hypha.aicell.io"})
+# Opens a logout URL; pass logout_callback=... to customize.
+```
+
+## Interactive Browser Login — JavaScript
+
+```javascript
+import { login, connectToServer } from "hypha-rpc";
+
+const token = await login({
+  server_url: "https://hypha.aicell.io",
+  // Optional:
+  // workspace: "ws-user-xyz",
+  // expires_in: 3600 * 24 * 30,
+  // login_timeout: 180,
+  // profile: true,
+  login_callback: async (context) => {
+    // context.login_url — show it to the user
+    window.open(context.login_url, "_blank");
+  },
+});
+
+const server = await connectToServer({
+  server_url: "https://hypha.aicell.io",
+  token,
+});
+```
+
+Without `login_callback`, `login()` logs the URL via `console.log`. In browser
+apps, always provide a callback that opens a popup or redirects — users can't
+see `console` output.
+
+### Logout
+
+```javascript
+import { logout } from "hypha-rpc";
+await logout({ server_url: "https://hypha.aicell.io" });
+```
+
+## Programmatic Tokens — `generate_token`
+
+Once connected with any authenticated identity, you can mint scoped tokens via
+the workspace manager (requires `admin` permission on the target workspace):
+
+```python
+async with connect_to_server({
+    "server_url": "https://hypha.aicell.io",
+    "token": admin_token,
+}) as server:
+    new_token = await server.generate_token({
+        "workspace": "ws-user-xyz",        # workspace to scope to
+        "permission": "read_write",         # read | read_write | admin
+        "expires_in": 86400,                # seconds
+        # Optional: "client_id", "user_id", "email"
+    })
+```
+
+Use this to hand out short-lived tokens to sub-agents, CI jobs, or users of a
+hosted app. The token inherits permissions no greater than the caller's own.
+
+## Token Expiration and Refresh
+
+Tokens carry a `exp` claim. On expiration, RPC calls fail with
+`ConnectionAbortedError: Authentication error: The token has expired`. Handle
+this by calling `login()` again or refreshing via `generate_token` from a
+longer-lived admin session.
+
+`hypha-rpc` does **not** auto-refresh tokens. If you need long-running agents,
+either:
+
+- Issue tokens with a long `expires_in` (at the cost of revocability), or
+- Wrap your connection in a reconnection loop that calls `login()` / `generate_token()` on auth failure.
+
+## Custom Auth Providers
+
+The `public/hypha-login` service and `login()` function assume the server uses
+the built-in Auth0 integration. If your Hypha deployment uses a custom auth
+provider (see [auth.md](auth.md)), use the provider-specific token flow and
+pass the resulting token directly to `connect_to_server`. You do not need
+`login()` at all — it's purely a convenience wrapper around
+`public/hypha-login`.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Failed to get the login service: public/hypha-login` | Server has no login service configured | Use `generate_token` or a pre-shared token instead |
+| `login_timeout` exceeded | User didn't finish the flow in time | Pass a larger `login_timeout` or a UI-friendly `login_callback` |
+| `The token has expired` | Token's `exp` passed | Re-run `login()` or `generate_token(...)` |
+| `PermissionError` on `generate_token` | Caller is not `admin` on target workspace | Use an admin token or request a smaller scope |
+| Browser callback never returns | Popup blocked, or wrong `report_url` domain | Allow popups, or display `login_url` in a clickable link |
+
+## See Also
+
+- [auth.md](auth.md) — Server-side authentication, Auth0 config, custom providers
+- [configurations.md](configurations.md) — Server startup flags and environment variables
+- `public/hypha-login` service reference — underlying RPC surface that `login()` wraps

--- a/hypha/skills.py
+++ b/hypha/skills.py
@@ -741,6 +741,8 @@ curl -X POST "{server_url}/{workspace}/services/SERVICE_ID/METHOD" \\
 
 Generate tokens (requires admin): `await server.generate_token({{"permission": "read_write", "expires_in": 86400}})`
 
+Full login flow (Python + JavaScript, `login_callback`, `generate_token`, expiration handling): [GUIDE/login.md](GUIDE/login.md). Server-side auth config: [GUIDE/auth.md](GUIDE/auth.md).
+
 ## Built-in Services
 
 | Service | Get via SDK | HTTP prefix | Reference |
@@ -755,13 +757,16 @@ Generate tokens (requires admin): `await server.generate_token({{"permission": "
 
 | Capability | Transport | Details |
 |-----------|-----------|---------|
+| Authentication & tokens | SDK + HTTP | [GUIDE/login.md](GUIDE/login.md), [GUIDE/auth.md](GUIDE/auth.md) |
 | Call remote services | SDK + HTTP | [REFERENCE.md](REFERENCE.md) |
 | Register services | SDK only | Requires WebSocket; ephemeral unless managed by server-apps |
-| Artifacts (files, datasets) | SDK + HTTP | Git-like versioning, presigned S3 URLs. [REFERENCE/artifact-manager.md](REFERENCE/artifact-manager.md) |
-| Serverless apps | SDK + HTTP | ASGI or Functions type. [GUIDE/asgi-apps.md](GUIDE/asgi-apps.md), [GUIDE/serverless-functions.md](GUIDE/serverless-functions.md) |
-| MCP endpoints | HTTP | `/{workspace}/mcp/{{svc_id}}/mcp` — expose services to Claude, Cursor, etc. |
-| A2A protocol | HTTP | `/{workspace}/a2a/{{svc_id}}` — agent-to-agent communication |
-| Vector search | SDK + HTTP | Semantic search over collections and services |
+| Artifacts (files, datasets) | SDK + HTTP | Git-like versioning, presigned S3 URLs. [REFERENCE/artifact-manager.md](REFERENCE/artifact-manager.md), [GUIDE/artifact-manager.md](GUIDE/artifact-manager.md) |
+| Serverless apps | SDK + HTTP | ASGI or Functions type. [GUIDE/apps.md](GUIDE/apps.md), [GUIDE/asgi-apps.md](GUIDE/asgi-apps.md), [GUIDE/serverless-functions.md](GUIDE/serverless-functions.md) |
+| MCP endpoints | HTTP | `/{workspace}/mcp/{{svc_id}}/mcp` — expose services to Claude, Cursor, etc. [GUIDE/mcp.md](GUIDE/mcp.md) |
+| A2A protocol | HTTP | `/{workspace}/a2a/{{svc_id}}` — agent-to-agent communication. [GUIDE/a2a.md](GUIDE/a2a.md) |
+| Vector search | SDK + HTTP | Semantic search over collections and services. [GUIDE/vector-search.md](GUIDE/vector-search.md) |
+| Workers (browser, conda, k8s…) | SDK | [GUIDE/workers.md](GUIDE/workers.md), [GUIDE/browser-worker.md](GUIDE/browser-worker.md), [GUIDE/conda-worker.md](GUIDE/conda-worker.md), [GUIDE/k8s.md](GUIDE/k8s.md) |
+| Server configuration | — | [GUIDE/configurations.md](GUIDE/configurations.md) |
 
 ## JavaScript Notes
 
@@ -791,8 +796,22 @@ const svc = await server.getService("service-id", {{ case_conversion: "camel", _
 - [REFERENCE.md](REFERENCE.md) — API reference overview with all services
 - [EXAMPLES.md](EXAMPLES.md) — Code examples for every feature
 - [WORKSPACE_CONTEXT.md](WORKSPACE_CONTEXT.md) — This workspace's current state
+- [GUIDE/login.md](GUIDE/login.md) — Login, `login_callback`, programmatic tokens, expiration handling
+- [GUIDE/auth.md](GUIDE/auth.md) — Auth0, custom auth providers, server-side identity
+- [GUIDE/configurations.md](GUIDE/configurations.md) — Server startup flags and environment variables
+- [GUIDE/artifact-manager.md](GUIDE/artifact-manager.md) — Datasets, files, versioning, S3-backed storage
+- [GUIDE/apps.md](GUIDE/apps.md) — Serverless app lifecycle and manifests
 - [GUIDE/asgi-apps.md](GUIDE/asgi-apps.md) — Deploy FastAPI/Django as Hypha services
 - [GUIDE/serverless-functions.md](GUIDE/serverless-functions.md) — Simple HTTP function endpoints
+- [GUIDE/mcp.md](GUIDE/mcp.md) — Expose services as MCP endpoints for Claude, Cursor, etc.
+- [GUIDE/a2a.md](GUIDE/a2a.md) — Agent-to-agent protocol integration
+- [GUIDE/vector-search.md](GUIDE/vector-search.md) — Embedding-backed semantic search
+- [GUIDE/workers.md](GUIDE/workers.md) — Worker types (browser, conda, terminal, k8s, mcp-proxy, a2a-proxy)
+- [GUIDE/service-type-annotation.md](GUIDE/service-type-annotation.md) — `@schema_method` and JSON Schema generation
+- [GUIDE/operate-files.md](GUIDE/operate-files.md) — Upload, download, multipart, presigned URLs
+- [GUIDE/zip-streaming.md](GUIDE/zip-streaming.md) — Streaming zip downloads of artifacts
+- [GUIDE/autoscaling.md](GUIDE/autoscaling.md) — Worker autoscaling policies
+- [GUIDE/service-load-balancing.md](GUIDE/service-load-balancing.md) — Selecting among replicas
 - Source code: `{server_url}/{workspace}/agent-skills/SOURCE/{{service-id}}/{{method}}`
 - Download all docs: `{server_url}/{workspace}/agent-skills/create-zip-file`
 """
@@ -2213,6 +2232,22 @@ For high-level usage, refer to REFERENCE.md and EXAMPLES.md.
             zf.writestr("EXAMPLES.md", get_examples_md(ws, server_url))
             zf.writestr("WORKSPACE_CONTEXT.md", get_workspace_context_md(ws, server_url, workspace_info, services))
 
+            # Bundle guide documents referenced from SKILL.md
+            guide_files = [
+                "login.md", "auth.md", "configurations.md",
+                "artifact-manager.md", "apps.md",
+                "asgi-apps.md", "serverless-functions.md",
+                "mcp.md", "a2a.md", "vector-search.md",
+                "workers.md", "browser-worker.md", "conda-worker.md",
+                "terminal-worker.md", "k8s.md",
+                "service-type-annotation.md", "service-load-balancing.md",
+                "operate-files.md", "zip-streaming.md", "autoscaling.md",
+            ]
+            for guide in guide_files:
+                guide_content = load_documentation_file(guide)
+                if guide_content is not None:
+                    zf.writestr(f"GUIDE/{guide}", guide_content)
+
             # Add source code for each enabled built-in service
             enabled_services = await doc_generator.get_all_enabled_services()
             # Derive service_id -> class_name from the module-level constant
@@ -2544,6 +2579,8 @@ curl -H "Authorization: Bearer TOKEN" "{server_url}/WORKSPACE/services/"
 token = await server.generate_token({{"permission": "read_write", "expires_in": 86400}})
 ```
 
+Full login flow with `login_callback`, programmatic token generation, and expiration handling: [GUIDE/login.md](GUIDE/login.md). Server-side auth configuration (Auth0, custom providers): [GUIDE/auth.md](GUIDE/auth.md).
+
 ## Built-in Services
 
 | Service | SDK ID | HTTP prefix | Reference |
@@ -2597,8 +2634,17 @@ const svc = await server.getService("svc-id", {{ case_conversion: "camel", _rkwa
 | API Reference | `{server_url}/ws/agent-skills/REFERENCE.md` |
 | Per-Service API | `{server_url}/ws/agent-skills/REFERENCE/{{service-id}}.md` |
 | Examples | `{server_url}/ws/agent-skills/EXAMPLES.md` |
+| Login Guide | `{server_url}/ws/agent-skills/GUIDE/login.md` |
+| Auth Guide | `{server_url}/ws/agent-skills/GUIDE/auth.md` |
+| Configuration Guide | `{server_url}/ws/agent-skills/GUIDE/configurations.md` |
+| Artifact Manager Guide | `{server_url}/ws/agent-skills/GUIDE/artifact-manager.md` |
+| Apps Guide | `{server_url}/ws/agent-skills/GUIDE/apps.md` |
 | ASGI Guide | `{server_url}/ws/agent-skills/GUIDE/asgi-apps.md` |
 | Functions Guide | `{server_url}/ws/agent-skills/GUIDE/serverless-functions.md` |
+| MCP Guide | `{server_url}/ws/agent-skills/GUIDE/mcp.md` |
+| A2A Guide | `{server_url}/ws/agent-skills/GUIDE/a2a.md` |
+| Vector Search Guide | `{server_url}/ws/agent-skills/GUIDE/vector-search.md` |
+| Workers Guide | `{server_url}/ws/agent-skills/GUIDE/workers.md` |
 
 ### Auth Required (Workspace-Specific)
 


### PR DESCRIPTION
## Summary

- Adds `docs/login.md` — focused agent-facing guide for client-side authentication: Python + JavaScript `login()` flow, `login_callback` patterns, programmatic `generate_token`, expiration handling, logout, troubleshooting. Sourced from the actual `hypha-rpc` client signatures so it doesn't drift.
- Audits agent-skills SKILL.md (workspace + global) to surface every existing `docs/` guide. Previously SKILL.md only referenced `GUIDE/asgi-apps.md` and `GUIDE/serverless-functions.md`; users following the public `/ws/agent-skills/SKILL.md` had no path to discover login flow, auth, artifact-manager, MCP, A2A, vector-search, workers, etc.
- Bundles 20 guide files under `GUIDE/` in the skills zip so offline agents see them.

## What changed

**`docs/login.md`** (new)
Covers all three token paths: interactive browser login, programmatic `generate_token`, pre-shared tokens. Includes JS + Python `login_callback` examples (callback receives `{login_url, key, report_url}` dict — verified against `hypha-rpc/python/hypha_rpc/websocket_client.py:833` and `hypha-rpc/javascript/src/websocket-client.js:650`).

**`hypha/skills.py`**
- Workspace `get_skill_md`: GUIDE/login.md + GUIDE/auth.md note in Authentication section; Capabilities table expanded to link auth, artifacts, apps, MCP, A2A, vector search, workers, configurations; 15 guide entries added to Further Reading.
- Global `get_global_skill_md`: same login note in Authentication; 9 new GUIDE entries in Documentation URLs.
- `handle_create_zip`: now writes 20 guide files (`login.md`, `auth.md`, `configurations.md`, `artifact-manager.md`, `apps.md`, `asgi-apps.md`, `serverless-functions.md`, `mcp.md`, `a2a.md`, `vector-search.md`, `workers.md`, browser/conda/terminal/k8s workers, `service-type-annotation.md`, `service-load-balancing.md`, `operate-files.md`, `zip-streaming.md`, `autoscaling.md`) to `GUIDE/` in the zip.

All linked guide files were verified to exist in `docs/`.

## Test plan

- [x] `pytest tests/test_skills.py` — 56/56 pass
- [x] `python -c \"import ast; ast.parse(open('hypha/skills.py').read())\"` — no syntax errors
- [x] All 20 referenced `docs/<guide>.md` files exist
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)