### PR TITLE
feat: connection admission control for reconnection storms (rebased from #938)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Hypha Change Log
 
+### 0.21.80
+
+ - Add connection admission control to prevent reconnection storms from overwhelming the server (configurable via `HYPHA_MAX_CONCURRENT_CONNECTIONS`, default 10)
+ - Reconnecting clients receive random jitter (0–1s) to spread reconnection load after server restarts
+
 ### 0.21.79
 
  - Add per-client WebSocket rate limiting to prevent RPC message spam (configurable via `HYPHA_WS_MSG_RATE_LIMIT`, `HYPHA_WS_MSG_BURST_LIMIT`)

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -1044,6 +1044,14 @@ Each user has a maximum number of workspaces they can own. The root user is exem
 |---------------------|---------|-------------|
 | `HYPHA_MAX_WORKSPACES_PER_USER` | `100` | Maximum number of workspaces a single user can own |
 
+### Connection Admission Control
+
+To prevent reconnection storms (e.g., after a server restart, when dozens of clients reconnect simultaneously) from saturating the event loop and Redis, Hypha limits the number of WebSocket connections being set up concurrently. Excess connections wait in a queue (up to 30 seconds) and reconnecting clients receive a small random delay (0–1s jitter) to spread the load.
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `HYPHA_MAX_CONCURRENT_CONNECTIONS` | `10` | Maximum number of WebSocket connections being set up simultaneously |
+
 ### Connection Idle Timeout
 
 Idle WebSocket connections are automatically disconnected after a configurable timeout. This is especially useful for cleaning up anonymous client connections that are no longer active.

--- a/hypha/websocket.py
+++ b/hypha/websocket.py
@@ -5,6 +5,7 @@ import sys
 import json
 import asyncio
 import time
+import random
 import msgpack
 
 from fastapi import Query, WebSocket, status
@@ -78,6 +79,14 @@ class WebsocketServer:
         # Per-client message rate limiting (token bucket)
         self._msg_rate_limit = float(os.environ.get("HYPHA_WS_MSG_RATE_LIMIT", "200"))
         self._msg_burst_limit = int(os.environ.get("HYPHA_WS_MSG_BURST_LIMIT", "2000"))
+        # Connection admission control: limit concurrent connection setups to
+        # prevent reconnection storms from saturating the event loop and Redis.
+        self._max_concurrent_connections = int(
+            os.environ.get("HYPHA_MAX_CONCURRENT_CONNECTIONS", "10")
+        )
+        self._connection_semaphore = asyncio.Semaphore(
+            self._max_concurrent_connections
+        )
         # Background task to clean up idle connections
         try:
             # Check if there's a running event loop before creating the coroutine
@@ -141,7 +150,31 @@ class WebsocketServer:
             # Track if we successfully authenticated for cleanup purposes
             authenticated = False
             user_info = None
-            
+
+            # Admission control: wait for a semaphore slot before doing
+            # the heavy auth + workspace-load + client-check work.
+            # This prevents 50+ simultaneous reconnections from hammering
+            # Redis with concurrent SCAN/DELETE operations.
+            try:
+                await asyncio.wait_for(
+                    self._connection_semaphore.acquire(), timeout=30
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Connection admission timeout — too many concurrent connections"
+                )
+                await self.disconnect(
+                    websocket,
+                    reason="Server busy, please retry",
+                    code=status.WS_1013_TRY_AGAIN_LATER,
+                )
+                return
+
+            # Add jitter for reconnecting clients to spread the load
+            if reconnection_token:
+                jitter = random.uniform(0, 1.0)
+                await asyncio.sleep(jitter)
+
             try:
                 if token or reconnection_token:
                     user_info, workspace = await self.authenticate_user(
@@ -222,7 +255,7 @@ class WebsocketServer:
                 # Log the full exception for debugging
                 logger.error(f"Exception during connection setup: {e}", exc_info=True)
                 reason = f"Failed to establish connection: {str(e)}"
-                
+
                 # If we authenticated but failed later, try to clean up
                 # This handles the case where check_client creates services but then fails
                 if authenticated and user_info and workspace and client_id:
@@ -234,13 +267,17 @@ class WebsocketServer:
                             logger.info(f"Cleaned up partially created client {workspace}/{client_id} after setup failure")
                     except Exception as cleanup_error:
                         logger.warning(f"Could not cleanup client after setup failure: {cleanup_error}")
-                
+
                 await self.disconnect(
                     websocket,
                     reason=reason,
                     code=status.WS_1001_GOING_AWAY,
                 )
                 return
+            finally:
+                # Release the admission semaphore after setup is done (or failed).
+                # The long-running communication loop does not need to hold the slot.
+                self._connection_semaphore.release()
 
             try:
                 await self.establish_websocket_communication(


### PR DESCRIPTION
## Summary

Cleanly rebased `feat/connection-admission-control` (PR #938) onto current main. Five of #938's six commits had already landed via #937 and #943/#945; this PR carries only the net-new commit: **connection admission control**.

Adds an `asyncio.Semaphore` (default 10) wrapping the heavy auth/workspace-load/check_client work in `WebsocketServer.handle_websocket_connection`, plus 0–1s jitter for reconnecting clients to spread load. Configurable via `HYPHA_MAX_CONCURRENT_CONNECTIONS`. After a server restart, 40–50 clients reconnecting simultaneously no longer saturate the event loop and Redis with parallel SCAN/DELETE; excess connections queue for up to 30s, then receive WS 1013 \"Try Again Later\".

## Why a new PR

PR #938 is in `CONFLICTING` state, has no CI runs, and 5/6 of its commits are already on main via other merged PRs (per-client WS rate limiting in #937; HTTP rate limit + service/workspace quotas in #943/#945). Force-pushing would erase that history; opening this clean PR and closing #938 is the lower-risk path.

## Code

`hypha/websocket.py` (only file touched here):
- `__init__`: `self._connection_semaphore = asyncio.Semaphore(int(os.environ.get(\"HYPHA_MAX_CONCURRENT_CONNECTIONS\", \"10\")))`
- `handle_websocket_connection`: `await asyncio.wait_for(self._connection_semaphore.acquire(), timeout=30)` before the inner setup `try`; jitter `await asyncio.sleep(random.uniform(0, 1.0))` for reconnection tokens; `finally: self._connection_semaphore.release()` after setup completes (success or fail), before the long-lived comm loop. The slot is held only for setup, not for the session.

## Test plan

- [x] `pytest tests/test_websocket_metrics.py tests/test_websocket_idle_toctou.py tests/test_websocket_reconnect_race.py tests/test_reconnection_register_service.py` — 11/11 pass
- [x] `pytest tests/test_resource_limits.py tests/test_http_rate_limit.py` — 44/44 pass
- [x] `pytest tests/test_services.py` — 9/9 pass
- [ ] CI green

Closes #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)