### PR TITLE
fix(auth): wildcard scope must not shadow stronger per-workspace grant (#958)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
             playwright-
       - name: Install conda dependencies
         run: |
-          conda install -c conda-forge conda-pack numpy ipykernel python=${{ matrix.python-version }}
+          conda install -c conda-forge conda-pack numpy ipykernel pip python=${{ matrix.python-version }}
           conda list
         shell: bash -l {0}
       - name: Install dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,6 +439,15 @@ All vulnerabilities documented with tests in `tests/test_security_vulnerabilitie
 | V6 | Missing ownership check | Verify ownership before destructive ops |
 | V9 | Conditional token validation | ALWAYS validate tokens |
 | V10-V14 | Cross-workspace bypass | Extract workspace from ID, validate permission on TARGET workspace |
+| V15 | Wildcard shadows specific permission | `get_permission` must return the STRONGEST of `*` and the per-workspace grant, never short-circuit on `*` |
+
+#### V15: Wildcard `*` Permission Shadows Specific Workspace Grant (HIGH — availability/authorization)
+
+- **Pattern**: `UserInfo.get_permission(ws)` returned the `"*"` (wildcard) scope whenever present, ignoring a stronger per-workspace entry.
+- **Root Cause**: `auth.get_user_info()` elevates a caller's own workspace to `admin` (`scope.workspaces[own_ws] = admin`), but `get_permission` did `if scope.workspaces.get("*"): return scope.workspaces["*"]` first. A login/session token carrying `*#rw` (below admin) shadowed the own-workspace admin grant, so a workspace owner who was not a global admin could not `generate_token` — and thus `apps.start` raised `Only admin can generate token`.
+- **Fix**: `get_permission` returns the maximum (by rank read < read_write < admin) of the `"*"` and specific-workspace permissions. `hypha/core/__init__.py::UserInfo.get_permission`.
+- **Location**: `hypha/core/__init__.py` (`get_permission`); failing call at `hypha/apps.py::start` → `hypha/core/workspace.py::generate_token`.
+- **Key Lesson**: Never let a broad-but-weaker scope mask a narrow-but-stronger grant. Aggregate permissions by strength. See amun-ai/hypha#958, tests in `tests/test_auth.py` and `tests/test_owner_generate_token.py`.
 
 ### Known Performance Anti-Patterns (NEVER DO)
 

--- a/hypha/core/__init__.py
+++ b/hypha/core/__init__.py
@@ -367,13 +367,28 @@ class UserInfo(BaseModel):
         self._metadata[key] = value
 
     def get_permission(self, workspace: str):
-        """Get the workspace permission."""
+        """Get the workspace permission.
+
+        Returns the STRONGEST of the wildcard ("*") permission and the
+        specific-workspace permission, so a per-workspace admin grant (e.g. the
+        own-workspace elevation in auth.get_user_info) is not shadowed by a
+        broader-but-weaker "*" scope. See amun-ai/hypha#958.
+        """
         if not self.scope:
             return None
         assert isinstance(workspace, str)
-        if self.scope.workspaces.get("*"):
-            return self.scope.workspaces["*"]
-        return self.scope.workspaces.get(workspace, None)
+        star = self.scope.workspaces.get("*")
+        specific = self.scope.workspaces.get(workspace)
+        _rank = {
+            UserPermission.read: 1,
+            UserPermission.read_write: 2,
+            UserPermission.admin: 3,
+        }
+        best = None
+        for p in (star, specific):
+            if p is not None and (best is None or _rank.get(p, 0) > _rank.get(best, 0)):
+                best = p
+        return best
 
     def check_permission(self, workspace: str, minimal_permission: UserPermission):
         permission = self.get_permission(workspace)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -309,6 +309,38 @@ def generate_admin_role_user_token():
         loop.close()
 
 
+@pytest_asyncio.fixture(name="wildcard_owner_user_token", scope="session")
+def generate_wildcard_owner_user_token():
+    """Token for a non-admin workspace owner carrying a weaker "*" scope.
+
+    Reproduces amun-ai/hypha#958: the user owns ``ws-user-wildcard-owner`` but
+    their token carries a broad ``*#rw`` scope (e.g. a login/session token)
+    *below* admin. Previously this weaker wildcard shadowed the own-workspace
+    admin elevation, so the owner could not ``generate_token`` (or start a
+    server-app) in their own workspace.
+    """
+    auth.JWT_SECRET = JWT_SECRET
+    user_info = UserInfo(
+        id="wildcard-owner",
+        is_anonymous=False,
+        email="wildcard-owner@test.com",
+        parent=None,
+        roles=[],
+        scope=create_scope(
+            workspaces={"*": UserPermission.read_write},
+            current_workspace="ws-user-wildcard-owner",
+        ),
+        expires_at=None,
+    )
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        token = loop.run_until_complete(generate_auth_token(user_info, 18000))
+        yield token
+    finally:
+        loop.close()
+
+
 @pytest_asyncio.fixture(name="test_user_token_temporary", scope="session")
 def generate_authenticated_user_temporary():
     """Generate a temporary test user token."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -165,6 +165,89 @@ class TestBasicAuth:
         # Test no permission
         assert not user_info.check_permission("ws4", UserPermission.read)
 
+    def test_get_permission_wildcard_does_not_shadow_specific(self):
+        """A specific-workspace grant must not be shadowed by a weaker "*".
+
+        Regression test for amun-ai/hypha#958: a workspace owner whose token
+        carries a broad "*" scope at a permission *lower* than admin (e.g. a
+        login/session token with ``*#rw``) was denied admin on their OWN
+        workspace because ``get_permission`` short-circuited on "*" and never
+        consulted the stronger per-workspace entry (set by
+        ``auth.get_user_info``). ``get_permission`` must return the STRONGEST
+        of the two.
+        """
+        # "*" is weaker than the specific own-workspace admin grant.
+        user_info = UserInfo(
+            id="owner",
+            is_anonymous=False,
+            email="owner@example.com",
+            roles=["user"],
+            scope=create_scope(
+                workspaces={
+                    "*": UserPermission.read_write,
+                    "ws-user-owner": UserPermission.admin,
+                }
+            ),
+        )
+        # Must surface the stronger specific grant, not the weaker wildcard.
+        assert user_info.get_permission("ws-user-owner") == UserPermission.admin
+        assert user_info.check_permission("ws-user-owner", UserPermission.admin)
+
+        # A workspace with only the wildcard still resolves to the wildcard.
+        assert user_info.get_permission("some-other-ws") == UserPermission.read_write
+        assert not user_info.check_permission("some-other-ws", UserPermission.admin)
+
+        # The reverse direction must also pick the strongest: wildcard admin
+        # must win over a weaker specific grant (no accidental downgrade).
+        admin_wildcard = UserInfo(
+            id="admin",
+            is_anonymous=False,
+            email="admin@example.com",
+            roles=["user"],
+            scope=create_scope(
+                workspaces={
+                    "*": UserPermission.admin,
+                    "ws-foo": UserPermission.read,
+                }
+            ),
+        )
+        assert admin_wildcard.get_permission("ws-foo") == UserPermission.admin
+        assert admin_wildcard.check_permission("ws-foo", UserPermission.admin)
+
+    def test_get_user_info_wildcard_does_not_shadow_own_workspace_admin(self):
+        """get_user_info elevates own workspace to admin even with weaker "*".
+
+        Regression test for amun-ai/hypha#958. ``get_user_info`` always sets
+        the caller's own workspace to admin, but that elevation was being
+        shadowed by a weaker "*" entry inside ``get_permission``.
+        """
+        current_time = datetime.datetime.now(datetime.timezone.utc)
+        expires_at = current_time + datetime.timedelta(seconds=3600)
+        expires_at_timestamp = timegm(expires_at.utctimetuple())
+
+        credentials = {
+            "sub": "auth0|owner-123",
+            "exp": expires_at_timestamp,
+            # Broad session token: read_write on everything, no admin.
+            "scope": "ws:*#rw",
+            AUTH0_NAMESPACE + "roles": ["user"],
+            AUTH0_NAMESPACE + "email": "owner@example.com",
+        }
+
+        user_info = get_user_info(credentials)
+        own_ws = user_info.get_workspace()
+
+        # The own-workspace admin elevation must be honored despite "*#rw".
+        assert user_info.scope.workspaces[own_ws] == UserPermission.admin
+        assert user_info.get_permission(own_ws) == UserPermission.admin
+        assert user_info.check_permission(own_ws, UserPermission.admin)
+
+        # Other workspaces still resolve to the weaker wildcard.
+        assert user_info.get_permission("ws-someone-else") == UserPermission.read_write
+        assert not user_info.check_permission(
+            "ws-someone-else", UserPermission.admin
+        )
+
     def test_update_user_scope(self):
         """Test updating user scope for workspace."""
         user_info = UserInfo(

--- a/tests/test_owner_generate_token.py
+++ b/tests/test_owner_generate_token.py
@@ -1,0 +1,56 @@
+"""Integration test for amun-ai/hypha#958.
+
+A workspace owner who is NOT a global admin must be able to ``generate_token``
+(and therefore start a server-app) in their OWN workspace, even when their
+token carries a broad ``*`` scope at a permission *lower* than admin.
+
+The bug: ``UserInfo.get_permission`` short-circuited on the ``*`` wildcard and
+never consulted the stronger per-workspace admin grant that
+``auth.get_user_info`` installs for the caller's own workspace. As a result
+``generate_token`` (called by ``apps.start``) raised
+``PermissionError: Only admin can generate token``.
+"""
+
+import pytest
+from hypha_rpc import connect_to_server
+
+from . import SERVER_URL_SQLITE
+
+# All test coroutines will be treated as marked with pytest.mark.asyncio
+pytestmark = pytest.mark.asyncio
+
+
+async def test_owner_with_wildcard_scope_can_generate_token(
+    fastapi_server_sqlite, wildcard_owner_user_token
+):
+    """Owner of ``ws-user-wildcard-owner`` can mint a token in their own ws.
+
+    Reproduces the exact failing call in ``apps.start``:
+    ``await ws.generate_token({"client_id": ...})``. The caller is a non-admin
+    user whose token holds only ``*#rw`` (below admin). Before the fix this
+    raised ``Only admin can generate token``.
+    """
+    api = await connect_to_server(
+        {
+            "name": "wildcard owner",
+            "server_url": SERVER_URL_SQLITE,
+            "token": wildcard_owner_user_token,
+        }
+    )
+    try:
+        # Connected into the user's own workspace.
+        assert api.config.workspace == "ws-user-wildcard-owner"
+
+        # This is the call that apps.start performs internally and that
+        # previously failed with "Only admin can generate token".
+        token = await api.generate_token({"client_id": "_rapp_test__rlb"})
+        assert isinstance(token, str) and token
+
+        # An explicit admin-permission token for the owned workspace must
+        # also be allowed (owner elevation must reach admin).
+        admin_token = await api.generate_token(
+            {"workspace": "ws-user-wildcard-owner", "permission": "admin"}
+        )
+        assert isinstance(admin_token, str) and admin_token
+    finally:
+        await api.disconnect()


### PR DESCRIPTION
## Summary

Fixes #958 — a workspace owner who is **not a global admin cannot start a server-app in their own workspace**:

```
PermissionError: Only admin can generate token.
  hypha/apps.py::start -> hypha/core/workspace.py::generate_token
```

## Root cause

`auth.get_user_info()` elevates the caller's own workspace to `admin`:

```python
info.scope.workspaces[info.get_workspace()] = UserPermission.admin
```

…but `UserInfo.get_permission()` short-circuited on the `"*"` wildcard and never consulted the per-workspace entry:

```python
if self.scope.workspaces.get("*"):
    return self.scope.workspaces["*"]   # shadows the own-workspace admin grant
return self.scope.workspaces.get(workspace, None)
```

So a login/session token carrying a `"*"` scope **below admin** (e.g. `*#rw`) shadowed the own-workspace admin elevation. `generate_token` (called by `apps.start`) then saw the weaker `*` permission and denied the owner access to their **own** workspace. The `owned_by()` fallback in `generate_token` never fired because `maximum_permission` was already truthy.

## Fix

Adopted the issue's **suggestion 1** (the most general): `get_permission` now returns the **strongest** of the `"*"` and specific-workspace permissions instead of short-circuiting on `"*"`. This also corrects every other call site that relies on `get_permission`.

## Tests (TDD — confirmed to reproduce, then pass)

- **`tests/test_auth.py`** — unit tests `test_get_permission_wildcard_does_not_shadow_specific` and `test_get_user_info_wildcard_does_not_shadow_own_workspace_admin`. Both **fail** against the original `get_permission` and pass with the fix.
- **`tests/test_owner_generate_token.py`** — integration test that connects as a non-admin owner with a `*#rw` token and calls `generate_token` in their own workspace (the exact `apps.start` path). Confirmed to raise `PermissionError: Only admin can generate token` without the fix.
- **`tests/conftest.py`** — `wildcard_owner_user_token` fixture.

Local run: full `tests/test_auth.py` (59), `tests/test_root_token.py`, and the new integration test all pass. Documented as pattern **V15** in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)