### PR TITLE
fix(shutdown): gracefully drain WS and HTTP-stream clients on teardown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -458,6 +458,30 @@ All vulnerabilities documented with tests in `tests/test_security_vulnerabilitie
 | `redis.keys(pattern)` in workspace ops | Blocks entire Redis for duration of scan | Use `redis.scan(cursor, match, count)` cursor-based iteration |
 | Unbounded `asyncio.wait_for()` on Redis ops | Can hang indefinitely if Redis is slow | Always add `timeout=5.0` to Redis operations in cleanup |
 
+### Graceful Shutdown / Connection Draining (Reliability)
+
+On a rollout/redeploy, abruptly cutting long-lived connections forces clients to
+detect the dead pod only via their heartbeat/read timeout — every client then
+reconnects in the same window, producing a thundering-herd reconnection storm on
+the new pod. **Always proactively signal connected clients to reconnect during
+graceful shutdown** so they re-establish immediately (and, with a preStop drain,
+land on the surviving replica).
+
+- **WebSocket**: `WebsocketServer.close_all_clients()` sends an explicit close
+  frame with code **1001 GOING_AWAY**. The hypha-rpc client reconnects on close
+  codes 1000/1001 when the close was not user-initiated.
+- **HTTP streaming** (`/rpc`): `HTTPStreamingRPCServer.close_all_streams()` pushes
+  the `None` sentinel into each active stream queue (the same signal used for
+  connection replacement), ending the StreamingResponse so the client sees a clean
+  EOF and reconnects. **This transport had NO graceful drain before F4** — only
+  WebSockets were closed in `store.teardown()`, so HTTP-stream clients (e.g. svamp
+  daemons) waited out their read timeout. Both transports are now drained in
+  `RedisStore.teardown()`.
+- **Key Lesson**: when adding any long-lived transport, wire it into the shutdown
+  drain path. A transport that is invisible to `teardown()` will always degrade to
+  timeout-based disconnect detection. Tracked as F4; see amun-ai/hypha (svamp
+  reliability audit).
+
 **Critical Pattern (V10-V14)**: When an ID contains a workspace prefix (e.g., `workspace/client_id`), always validate permission on the embedded workspace, not just `context["ws"]`.
 
 ```python

--- a/hypha/core/store.py
+++ b/hypha/core/store.py
@@ -236,6 +236,7 @@ class RedisStore:
         self._ready = False
         self._workspace_manager = None
         self._websocket_server = None
+        self._http_streaming_server = None
         self._cache_dir = cache_dir
         self._server_id = server_id or random_id(readable=True)
         self._manager_id = "manager-" + self._server_id
@@ -372,6 +373,10 @@ class RedisStore:
         """Set the websocket server."""
         assert self._websocket_server is None, "Websocket server already set"
         self._websocket_server = websocket_server
+
+    def set_http_streaming_server(self, http_streaming_server):
+        """Set the HTTP streaming RPC server (used for graceful drain)."""
+        self._http_streaming_server = http_streaming_server
 
 
     @schema_method
@@ -1457,13 +1462,20 @@ class RedisStore:
         except Exception as e:
             logger.warning(f"Error removing root workspace client: {e}")
         
+        # Graceful drain: proactively signal connected clients to reconnect with
+        # an explicit "going away" close so they re-establish immediately on the
+        # surviving replica, instead of waiting out a heartbeat/read timeout
+        # (which causes a thundering-herd reconnection storm on rollout).
         if self._websocket_server:
-            websockets = self._websocket_server.get_websockets()
-            for ws in websockets.values():
-                try:
-                    await ws.close()
-                except GeneratorExit:
-                    pass
+            try:
+                await self._websocket_server.close_all_clients()
+            except Exception as e:
+                logger.warning(f"Error closing websocket clients on teardown: {e}")
+        if self._http_streaming_server:
+            try:
+                await self._http_streaming_server.close_all_streams()
+            except Exception as e:
+                logger.warning(f"Error closing HTTP streams on teardown: {e}")
 
         await self._event_bus.stop()
         # Close Redis client gracefully

--- a/hypha/http_rpc.py
+++ b/hypha/http_rpc.py
@@ -151,6 +151,37 @@ class HTTPStreamingRPCServer:
         except Exception as e:
             logger.warning(f"Error disconnecting: {e}")
 
+    async def close_all_streams(self) -> int:
+        """Signal every active HTTP streaming connection to close cleanly.
+
+        Used during graceful shutdown (SIGTERM/rollout). Pushes the ``None``
+        sentinel that ``stream_messages()`` interprets as a close signal, which
+        ends the StreamingResponse so the client observes a clean stream EOF and
+        reconnects immediately — instead of waiting for its read/heartbeat
+        timeout, which would otherwise produce a reconnection storm when a pod
+        is redeployed.
+
+        Returns the number of connections that were signaled.
+        """
+        async with self._lock:
+            queues = list(self._connections.values())
+        if not queues:
+            return 0
+        count = 0
+        for queue in queues:
+            try:
+                queue.put_nowait(None)  # None signals stream to close
+                count += 1
+            except asyncio.QueueFull:
+                # Queue backed up by a slow client; the stream will still end via
+                # request.is_disconnected() once the socket drops. We cannot
+                # block here during shutdown.
+                logger.warning(
+                    "Stream queue full during shutdown; relying on disconnect detection"
+                )
+        logger.info("Signaled %d HTTP streaming connection(s) to close", count)
+        return count
+
     async def _authenticate_with_reconnection_token(
         self, reconnection_token: str, client_id: str, workspace: str
     ) -> tuple[UserInfo, str]:

--- a/hypha/server.py
+++ b/hypha/server.py
@@ -144,7 +144,8 @@ def start_builtin_services(
         )
 
     # Set up HTTP Streaming RPC (always enabled)
-    setup_http_rpc(store, app, base_path=args.base_path)
+    http_streaming_server = setup_http_rpc(store, app, base_path=args.base_path)
+    store.set_http_streaming_server(http_streaming_server)
     logger.info("HTTP Streaming RPC enabled")
 
     # Register agent skills service BEFORE HTTPProxy (must be registered before _ready=True)

--- a/hypha/websocket.py
+++ b/hypha/websocket.py
@@ -726,6 +726,46 @@ class WebsocketServer:
         """Check if the server is alive."""
         return True
 
+    async def close_all_clients(
+        self,
+        code=status.WS_1001_GOING_AWAY,
+        reason="Server is shutting down",
+    ):
+        """Proactively send a close frame to every active websocket client.
+
+        Used during graceful shutdown (SIGTERM/rollout): emitting an explicit
+        "going away" close frame lets clients reconnect immediately instead of
+        waiting out their heartbeat timeout, which prevents a thundering-herd
+        reconnection storm when a pod is redeployed.
+
+        The hypha-rpc client treats close codes 1000/1001 (when not
+        user-initiated) as a signal to reconnect, so a single replica draining
+        its connections hands clients straight to the surviving replica.
+
+        Returns the number of clients that were signaled.
+        """
+        websockets = list(self._websockets.values())
+        if not websockets:
+            return 0
+        logger.info(
+            "Gracefully closing %d websocket client(s) with code %s",
+            len(websockets),
+            code,
+        )
+
+        async def _close(ws):
+            try:
+                if ws.client_state.name == "CONNECTED":
+                    await ws.close(code=code, reason=reason)
+            except GeneratorExit:
+                pass  # Suppress GeneratorExit to avoid RuntimeError
+            except Exception as e:
+                # One unresponsive socket must not block draining the rest.
+                logger.warning("Error closing websocket during shutdown: %s", e)
+
+        await asyncio.gather(*[_close(ws) for ws in websockets])
+        return len(websockets)
+
     async def stop(self):
         """Stop the server."""
         self._stop = True

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -1,0 +1,184 @@
+"""Tests for graceful-shutdown connection draining (F4).
+
+On a server rollout/redeploy, abruptly cutting long-lived connections forces
+clients to detect the dead pod only via their heartbeat/read timeout, producing
+a thundering-herd reconnection storm. The fix proactively signals connected
+clients to reconnect:
+
+- WebSocket clients receive an explicit close frame (1001 GOING_AWAY).
+- HTTP-streaming clients receive the ``None`` sentinel that ends their stream
+  cleanly (clean EOF -> immediate reconnect).
+
+No mocks: these exercise the real ``close_all_clients`` / ``close_all_streams``
+methods against minimal in-process stand-ins, mirroring the pattern in
+test_websocket_idle_toctou.py.
+"""
+import asyncio
+
+import pytest
+from fastapi import status
+
+pytestmark = pytest.mark.asyncio
+
+
+# --------------------------------------------------------------------------- #
+# WebSocket: close_all_clients
+# --------------------------------------------------------------------------- #
+class _ClientState:
+    """Minimal stand-in for starlette WebSocketState (only .name is used)."""
+
+    def __init__(self, name="CONNECTED"):
+        self.name = name
+
+
+class _SimpleWS:
+    """Minimal WebSocket stand-in recording close() calls."""
+
+    def __init__(self, state="CONNECTED", raise_on_close=False):
+        self.client_state = _ClientState(state)
+        self.raise_on_close = raise_on_close
+        self.closed_with = None  # (code, reason) once closed
+
+    async def close(self, code=status.WS_1000_NORMAL_CLOSURE, reason=None):
+        if self.raise_on_close:
+            raise RuntimeError("socket already gone")
+        self.closed_with = (code, reason)
+        self.client_state.name = "CLOSED"
+
+
+def _make_ws_server():
+    """Create a minimal WebsocketServer instance bypassing __init__."""
+    from hypha.websocket import WebsocketServer
+
+    server = WebsocketServer.__new__(WebsocketServer)
+    server._stop = False
+    server._websockets = {}
+    return server
+
+
+async def test_close_all_clients_signals_every_connection_with_going_away():
+    """Every active websocket must receive a 1001 GOING_AWAY close frame."""
+    server = _make_ws_server()
+    sockets = {f"ws/client-{i}": _SimpleWS() for i in range(5)}
+    server._websockets = dict(sockets)
+
+    count = await server.close_all_clients()
+
+    assert count == 5
+    for ws in sockets.values():
+        assert ws.closed_with is not None, "Client was not signaled to close"
+        code, reason = ws.closed_with
+        assert code == status.WS_1001_GOING_AWAY
+        assert reason == "Server is shutting down"
+
+
+async def test_close_all_clients_empty_is_noop():
+    """Draining with no active connections returns 0 and does not raise."""
+    server = _make_ws_server()
+    assert await server.close_all_clients() == 0
+
+
+async def test_close_all_clients_skips_already_closed():
+    """A socket that is no longer CONNECTED must not be closed again."""
+    server = _make_ws_server()
+    already = _SimpleWS(state="CLOSED")
+    live = _SimpleWS()
+    server._websockets = {"ws/a": already, "ws/b": live}
+
+    await server.close_all_clients()
+
+    # already-closed socket: close() never invoked (closed_with stays None)
+    assert already.closed_with is None
+    assert live.closed_with is not None
+
+
+async def test_close_all_clients_continues_when_one_socket_errors():
+    """One unresponsive socket must not prevent draining the others."""
+    server = _make_ws_server()
+    bad = _SimpleWS(raise_on_close=True)
+    good1 = _SimpleWS()
+    good2 = _SimpleWS()
+    server._websockets = {"ws/bad": bad, "ws/g1": good1, "ws/g2": good2}
+
+    count = await server.close_all_clients()
+
+    assert count == 3  # all were attempted
+    assert good1.closed_with is not None
+    assert good2.closed_with is not None
+
+
+async def test_close_all_clients_custom_code_and_reason():
+    """Caller-provided code/reason are honored."""
+    server = _make_ws_server()
+    ws = _SimpleWS()
+    server._websockets = {"ws/a": ws}
+
+    await server.close_all_clients(code=status.WS_1012_SERVICE_RESTART, reason="bye")
+
+    assert ws.closed_with == (status.WS_1012_SERVICE_RESTART, "bye")
+
+
+# --------------------------------------------------------------------------- #
+# HTTP streaming: close_all_streams
+# --------------------------------------------------------------------------- #
+def _make_http_server():
+    """Create a minimal HTTPStreamingRPCServer instance bypassing __init__."""
+    from hypha.http_rpc import HTTPStreamingRPCServer
+
+    server = HTTPStreamingRPCServer.__new__(HTTPStreamingRPCServer)
+    server._connections = {}
+    server._connection_info = {}
+    server._lock = asyncio.Lock()
+    return server
+
+
+async def test_close_all_streams_pushes_sentinel_to_every_queue():
+    """Each active stream queue must receive the None close sentinel."""
+    server = _make_http_server()
+    queues = {}
+    for i in range(4):
+        q = asyncio.Queue(maxsize=100)
+        queues[f"ws/client-{i}"] = q
+        server._connections[f"ws/client-{i}"] = q
+
+    count = await server.close_all_streams()
+
+    assert count == 4
+    for q in queues.values():
+        assert q.qsize() == 1
+        assert q.get_nowait() is None, "Stream was not signaled to close"
+
+
+async def test_close_all_streams_empty_is_noop():
+    """Draining with no active streams returns 0 and does not raise."""
+    server = _make_http_server()
+    assert await server.close_all_streams() == 0
+
+
+async def test_close_all_streams_tolerates_full_queue():
+    """A backed-up (full) queue must not abort draining of the others."""
+    server = _make_http_server()
+    full = asyncio.Queue(maxsize=1)
+    full.put_nowait(b"pending")  # now full
+    ok = asyncio.Queue(maxsize=100)
+    server._connections = {"ws/full": full, "ws/ok": ok}
+
+    # Must not raise despite the full queue.
+    count = await server.close_all_streams()
+
+    # Only the queue with capacity was signaled.
+    assert count == 1
+    assert ok.get_nowait() is None
+
+
+async def test_close_all_streams_sentinel_matches_stream_close_contract():
+    """The sentinel value must be exactly None (what stream_messages() checks)."""
+    server = _make_http_server()
+    q = asyncio.Queue(maxsize=100)
+    server._connections = {"ws/a": q}
+
+    await server.close_all_streams()
+
+    # stream_messages() does `if data is None: break` — anything else would not
+    # terminate the stream cleanly.
+    assert q.get_nowait() is None


### PR DESCRIPTION
## Problem (F4 — svamp reliability audit)

On a server rollout/redeploy, the old pod cuts long-lived connections abruptly. Clients then detect the dead pod only via their heartbeat/read timeout (10–20s) and all reconnect within the same window — a **thundering-herd reconnection storm** on the new pod.

**Root cause:** `RedisStore.teardown()` closed only WebSocket connections (with a bare code `1000`). The HTTP-streaming `/rpc` transport — used by svamp daemons — had **no graceful drain at all**, so those clients waited out their read timeout.

## Fix

- **`WebsocketServer.close_all_clients()`** — sends an explicit **`1001 GOING_AWAY`** close frame to every active socket. hypha-rpc reconnects on close codes `1000/1001` when the close was not user-initiated, so clients re-establish immediately.
- **`HTTPStreamingRPCServer.close_all_streams()`** — pushes the existing `None` stream-close sentinel into every active queue, ending the `StreamingResponse` so the client sees a clean EOF and reconnects.
- **`RedisStore.teardown()`** now drains both transports; the HTTP streaming server is registered on the store (`setup_http_rpc`'s return value was previously discarded).

Combined with a k8s `preStop` drain (deployment manifests — separate repo) clients land on the surviving replica instead of reconnecting into a herd.

## Tests

`tests/test_graceful_shutdown.py` — 9 unit tests exercising both drain methods against the real methods (no mocks), following the `__new__`-bypass pattern of `test_websocket_idle_toctou.py`:
- WS: signals every client with 1001 + reason; skips already-closed; continues when one socket errors; honors custom code/reason; empty no-op.
- HTTP stream: pushes `None` sentinel to every queue; tolerates full queues; empty no-op; sentinel matches the `stream_messages()` close contract.

## Notes

The companion **k8s preStop graceful-drain** (`terminationGracePeriodSeconds` + `preStop` sleep) lives in the deployment manifests, not this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)