### PR TITLE
ci(publish): provision pip in conda env before PyPI publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,12 @@ jobs:
 
     - name: Upgrade pip
       run: |
-        python -m pip install pip
+        # The conda env created by setup-miniconda can resolve without pip,
+        # making `python -m pip` fail with "No module named pip". Provision pip
+        # via conda first so it is deterministically present (mirrors the
+        # test-env fix in 78855189), then upgrade it.
+        conda install -y -c conda-forge pip
+        python -m pip install --upgrade pip
         pip --version
       shell: bash -l {0}
 


### PR DESCRIPTION
## Problem

The **Publish to PyPI** workflow (`publish.yml`) failed when cutting the 0.21.86 release:

```
/usr/share/miniconda/envs/test/bin/python: No module named pip
##[error]Process completed with exit code 1
```

The conda env created by `setup-miniconda` can resolve **without pip**, so the "Upgrade pip" step's `python -m pip install pip` fails before anything is built/published.

## Fix

Provision pip via `conda install -c conda-forge pip` before upgrading it — same root-cause fix as `78855189` ("ci: ensure pip is present in conda test-env") applied to `test.yml`.

## Note

The 0.21.86 release publish was unblocked by dispatching this workflow from this branch (`workflow_dispatch` builds from `hypha/VERSION`, independent of the release tag). This PR makes the fix permanent on `main` for future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)