### PR TITLE
feat(f6): Redis leader-lease primitive (Phase 0)

### DIFF
--- a/hypha/core/leader.py
+++ b/hypha/core/leader.py
@@ -1,0 +1,178 @@
+"""Redis-backed single-leader election (F6, Phase 0).
+
+An "exactly-one-runner" primitive for the control-plane singletons that must NOT
+run on every replica in a multi-replica deployment — the autoscaling monitor
+(``apps.py`` ``AutoscalingManager``) and the workspace activity-cleanup loop
+(``workspace.py`` ``WorkspaceActivityManager``). Each replica runs a
+``LeaderLease``; only the current leader runs the gated work, and the rest serve
+all client traffic normally.
+
+Mechanism:
+- **Acquire**: ``SET key identity NX PX ttl`` — atomic, only one replica wins.
+- **Renew**: a ``WATCH``/``MULTI`` compare-and-extend (``PEXPIRE`` iff we still
+  hold the key) — atomic without Lua, so it works on both real Redis and the
+  in-process ``fakeredis`` used for single-server/dev mode.
+- **Failover**: on leader crash the key expires after ``ttl_ms`` and another
+  replica acquires it on its next renew tick.
+
+This is a *best-effort* lease, not a strongly-consistent lock: during failover
+there can be a brief window with no leader, and (very briefly, around a missed
+renew) two instances could both believe they hold it. The gated work is
+therefore required to be **idempotent / overlap-tolerant** — which the autoscaling
+and cleanup loops are (Redis is the source of truth and the operations are
+idempotent). See ``docs/multi-replica-design.md`` §3.1.
+"""
+import asyncio
+import logging
+
+logger = logging.getLogger("leader")
+
+
+class LeaderLease:
+    """Best-effort single-leader election over a shared Redis key."""
+
+    def __init__(
+        self,
+        redis,
+        identity,
+        *,
+        key: str = "hypha:leader",
+        ttl_ms: int = 15000,
+        renew_interval: float = 5.0,
+    ):
+        """Create a leader lease.
+
+        Args:
+            redis: An async Redis client (real ``redis.asyncio`` or ``fakeredis``).
+            identity: Unique identifier for this replica (e.g. the store's
+                ``server_id``). Used as the lock value so renew/release only
+                affect a lease we actually hold.
+            key: The shared Redis key all replicas contend on.
+            ttl_ms: Lease lifetime in milliseconds. Must exceed two renew
+                intervals so a single missed renew does not drop the lease.
+            renew_interval: Seconds between renew/acquire attempts.
+        """
+        if ttl_ms <= renew_interval * 1000 * 2:
+            raise ValueError(
+                f"ttl_ms ({ttl_ms}) must exceed 2x renew_interval "
+                f"({renew_interval * 1000 * 2} ms) so one missed renew does not "
+                "drop the lease"
+            )
+        self._redis = redis
+        self._identity = (
+            identity if isinstance(identity, bytes) else str(identity).encode()
+        )
+        self._key = key
+        self._ttl_ms = int(ttl_ms)
+        self._renew_interval = renew_interval
+        self._is_leader = False
+        self._task = None
+        self._stopped = False
+
+    def is_leader(self) -> bool:
+        """Whether this replica currently believes it holds the lease.
+
+        Updated on each renew tick; may lag reality by up to ``renew_interval``.
+        Gated work must tolerate brief overlap (see module docstring).
+        """
+        return self._is_leader
+
+    async def _acquire(self) -> bool:
+        """Atomically acquire the lease iff it is currently free."""
+        ok = await self._redis.set(
+            self._key, self._identity, nx=True, px=self._ttl_ms
+        )
+        return bool(ok)
+
+    async def _contend(self) -> bool:
+        """Ensure leadership in one atomic step: extend if we hold it, acquire if
+        it is free, yield if another replica holds it (CAS via WATCH/MULTI).
+
+        This single operation covers both the leader (extend) and follower
+        (acquire-if-free) states, so the renew loop need not track which branch
+        it is in — avoiding a class of bugs where a key we already own is not
+        recognized by a plain ``SET NX`` acquire. Returns whether we hold it
+        afterward.
+        """
+        async with self._redis.pipeline() as pipe:
+            try:
+                await pipe.watch(self._key)
+                val = await pipe.get(self._key)
+                if val == self._identity:
+                    pipe.multi()
+                    pipe.pexpire(self._key, self._ttl_ms)
+                    await pipe.execute()
+                    return True
+                await pipe.unwatch()
+                if val is None:
+                    # Lease lapsed/free — try to take it.
+                    return await self._acquire()
+                return False
+            except Exception as e:
+                # WatchError (key changed under us) or a transient Redis error:
+                # treat as "not held" and re-contend on the next tick.
+                logger.debug("leader renew transaction failed: %s", e)
+                return False
+
+    async def _release(self) -> None:
+        """Delete the key iff we hold it (CAS), so we don't drop a peer's lease."""
+        async with self._redis.pipeline() as pipe:
+            try:
+                await pipe.watch(self._key)
+                val = await pipe.get(self._key)
+                if val == self._identity:
+                    pipe.multi()
+                    pipe.delete(self._key)
+                    await pipe.execute()
+                else:
+                    await pipe.unwatch()
+            except Exception as e:
+                logger.debug("leader release transaction failed: %s", e)
+
+    async def _loop(self) -> None:
+        while not self._stopped:
+            try:
+                was_leader = self._is_leader
+                held = await self._contend()
+                if held and not was_leader:
+                    logger.info("Acquired leader lease (%s)", self._identity.decode())
+                elif was_leader and not held:
+                    logger.info("Lost leader lease (%s)", self._identity.decode())
+                self._is_leader = held
+            except Exception as e:
+                logger.warning("leader loop error: %s", e)
+                self._is_leader = False
+            await asyncio.sleep(self._renew_interval)
+
+    async def start(self) -> None:
+        """Begin contending for leadership and start the renew loop.
+
+        Does one immediate acquire attempt so ``is_leader()`` is meaningful
+        immediately after ``start()`` returns.
+        """
+        self._stopped = False
+        try:
+            self._is_leader = await self._contend()
+            if self._is_leader:
+                logger.info("Acquired leader lease (%s)", self._identity.decode())
+        except Exception as e:
+            logger.warning("initial leader acquire failed: %s", e)
+            self._is_leader = False
+        self._task = asyncio.create_task(self._loop())
+
+    async def stop(self) -> None:
+        """Stop the renew loop and release the lease if we hold it."""
+        self._stopped = True
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        if self._is_leader:
+            try:
+                await self._release()
+            except Exception as e:
+                logger.debug("leader release on stop failed: %s", e)
+        self._is_leader = False

--- a/tests/test_leader_lease.py
+++ b/tests/test_leader_lease.py
@@ -1,0 +1,155 @@
+"""Tests for the Redis-backed LeaderLease single-leader election (F6, Phase 0).
+
+Real tests against a shared in-process fakeredis (no mocks). Two LeaderLease
+instances sharing ONE fakeredis client mirror two hypha replicas sharing one
+Redis — exactly the topology the primitive exists for.
+"""
+import asyncio
+
+import pytest
+from fakeredis import aioredis as fakeredis
+
+from hypha.core.leader import LeaderLease
+
+pytestmark = pytest.mark.asyncio
+
+
+def _redis():
+    """A fresh shared fakeredis client (acts as the one Redis both replicas use)."""
+    return fakeredis.FakeRedis()
+
+
+async def test_single_instance_acquires_leadership():
+    r = _redis()
+    lease = LeaderLease(r, "server-a", ttl_ms=2000, renew_interval=0.5)
+    assert lease.is_leader() is False  # not before start
+    await lease.start()
+    try:
+        assert lease.is_leader() is True
+    finally:
+        await lease.stop()
+    assert lease.is_leader() is False  # not after stop
+
+
+async def test_only_one_leader_across_two_instances():
+    r = _redis()  # shared Redis
+    a = LeaderLease(r, "server-a", ttl_ms=2000, renew_interval=0.5)
+    b = LeaderLease(r, "server-b", ttl_ms=2000, renew_interval=0.5)
+    await a.start()
+    await b.start()
+    try:
+        leaders = [x for x in (a, b) if x.is_leader()]
+        assert len(leaders) == 1, "exactly one instance must be leader"
+        assert a.is_leader() and not b.is_leader()  # a started first → a wins
+    finally:
+        await a.stop()
+        await b.stop()
+
+
+async def test_release_on_stop_lets_other_acquire():
+    r = _redis()
+    a = LeaderLease(r, "server-a", ttl_ms=2000, renew_interval=0.5)
+    await a.start()
+    assert a.is_leader()
+    # Graceful handover: a releases its key on stop.
+    await a.stop()
+    assert (await r.get("hypha:leader")) is None  # freed by CAS-release
+    # A follower can now take the free key.
+    b = LeaderLease(r, "server-b", ttl_ms=2000, renew_interval=0.5)
+    assert await b._contend() is True
+    assert (await r.get("hypha:leader")) == b"server-b"
+
+
+async def test_renew_extends_ttl():
+    r = _redis()
+    lease = LeaderLease(r, "server-a", ttl_ms=3000, renew_interval=1.0)
+    assert await lease._acquire() is True
+    lease._is_leader = True
+    await asyncio.sleep(0.2)
+    pttl_before = await r.pttl("hypha:leader")
+    assert pttl_before < 3000  # has decayed
+    assert await lease._contend() is True
+    pttl_after = await r.pttl("hypha:leader")
+    assert pttl_after > pttl_before  # extended back toward full ttl
+    await lease.stop()
+
+
+async def test_renew_returns_false_when_not_owner():
+    r = _redis()
+    a = LeaderLease(r, "server-a", ttl_ms=2000, renew_interval=0.5)
+    b = LeaderLease(r, "server-b", ttl_ms=2000, renew_interval=0.5)
+    assert await a._acquire() is True
+    a._is_leader = True
+    # b does not own the key → renew must NOT extend or steal it
+    assert await b._contend() is False
+    assert b.is_leader() is False
+    # a still holds it
+    assert (await r.get("hypha:leader")) == b"server-a"
+    await a.stop()
+
+
+async def test_release_does_not_drop_peer_lease():
+    r = _redis()
+    a = LeaderLease(r, "server-a", ttl_ms=2000, renew_interval=0.5)
+    b = LeaderLease(r, "server-b", ttl_ms=2000, renew_interval=0.5)
+    assert await a._acquire() is True
+    # b never owned it; releasing must be a no-op and leave a's key intact.
+    b._is_leader = True  # pretend b mistakenly thinks it leads
+    await b._release()
+    assert (await r.get("hypha:leader")) == b"server-a"
+    await a.stop()
+
+
+async def test_failover_after_expiry():
+    r = _redis()
+    a = LeaderLease(r, "server-a", ttl_ms=300, renew_interval=0.1)
+    b = LeaderLease(r, "server-b", ttl_ms=300, renew_interval=0.1)
+    assert await a._acquire() is True
+    a._is_leader = True
+    # Simulate a crashing without releasing: stop renewing and let the key lapse.
+    await r.pexpire("hypha:leader", 1)
+    await asyncio.sleep(0.05)
+    assert (await r.get("hypha:leader")) is None  # lease expired
+    # b acquires on its next attempt
+    assert await b._acquire() is True
+    b._is_leader = True
+    assert b.is_leader() is True
+    await b.stop()
+
+
+async def test_failover_via_loop_after_leader_stops():
+    """End-to-end: leader stops, follower's renew loop promotes it within a tick."""
+    r = _redis()
+    a = LeaderLease(r, "server-a", ttl_ms=400, renew_interval=0.1)
+    b = LeaderLease(r, "server-b", ttl_ms=400, renew_interval=0.1)
+    await a.start()
+    await b.start()
+    assert a.is_leader() and not b.is_leader()
+    await a.stop()  # releases the key
+    # b's loop should acquire within a couple of renew intervals
+    for _ in range(20):
+        await asyncio.sleep(0.05)
+        if b.is_leader():
+            break
+    assert b.is_leader() is True, "follower must take leadership after leader stops"
+    await b.stop()
+
+
+async def test_ttl_must_exceed_two_renew_intervals():
+    r = _redis()
+    with pytest.raises(ValueError):
+        LeaderLease(r, "server-a", ttl_ms=1000, renew_interval=1.0)  # 1000 <= 2000
+
+
+async def test_custom_key_isolates_leases():
+    r = _redis()
+    a = LeaderLease(r, "server-a", key="lease:alpha", ttl_ms=2000, renew_interval=0.5)
+    b = LeaderLease(r, "server-b", key="lease:beta", ttl_ms=2000, renew_interval=0.5)
+    await a.start()
+    await b.start()
+    try:
+        # Different keys → both can be leaders of their own lease.
+        assert a.is_leader() and b.is_leader()
+    finally:
+        await a.stop()
+        await b.stop()


### PR DESCRIPTION
## F6 Phase 0 — leader-lease primitive

First implementation increment of F6 (multi-replica hypha-server, see `docs/multi-replica-design.md`). Adds the **"exactly-one-runner"** primitive that later phases use to gate control-plane singletons (autoscaling monitor, workspace activity-cleanup) so they don't run on every replica.

**This PR is the primitive only — no consumers wired yet** (that's Phase 1), so it changes no runtime behavior.

### `hypha/core/leader.py` — `LeaderLease`
- **Acquire:** `SET key identity NX PX ttl` (atomic; one winner).
- **Renew/contend:** `WATCH`/`MULTI` compare-and-extend — atomic **without Lua**, so it works on both real Redis and the in-process `fakeredis` used for single-server/dev mode (fakeredis has no `EVAL`).
- **Failover:** on leader crash the key expires after `ttl_ms`; a follower acquires on its next renew tick.
- **Best-effort by design:** a brief overlap is possible around failover, so gated work must be idempotent — which the autoscaling/cleanup loops are (Redis is source of truth). See design doc §3.1.

### Tests — `tests/test_leader_lease.py` (real fakeredis, no mocks)
Two `LeaderLease` instances sharing one fakeredis mirror two replicas sharing one Redis. 10 tests: single-leader acquisition; exactly-one-leader across two instances; graceful handover on stop; CAS renew extends ttl; renew/release never steal or drop a peer's lease; failover after expiry; end-to-end loop promotion; ttl/renew-interval guard; key isolation. All passing.

### Context
Gate-(a) (cross-replica `targeted:` RPC delivery) is already empirically green (`test_server_scalability`), so the multi-replica routing premise holds. Next (Phase 1): wire `is_leader()` into the store and gate idempotent startup + the autoscaling/cleanup loops — that's the merge+release that unblocks the infra-side N→2 flip (kth-k8s PR #25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)