### PR TITLE
feat(f6): per-workspace lock for activity cleanup (Phase 1, P3)

### DIFF
--- a/docs/multi-replica-design.md
+++ b/docs/multi-replica-design.md
@@ -73,7 +73,7 @@ registry. See §5.
 | P1b | **Local-client fast-path misroutes on replica migration.** Targeted messages to a client in a replica's in-memory `_local_clients` set skip Redis. If a client moves to another replica, the *old* replica still has it locally and delivers to a dead socket instead of publishing to Redis for the new owner. (Sticky affinity makes this moot — see §5.) | **MED** (HIGH without affinity) | `core/__init__.py` ~1505–1514; `_local_clients` ~1210 | Per-instance registry, not Redis-backed with TTL |
 | P1c | **Manager affinity.** Each replica runs `manager-{server_id}`; clients cache a `manager_id` and route manager RPC to it. Reconnect to a different replica → calls target the old manager. (hypha-rpc 0.21.41/F1 retargets `wm`/getService to the new `manager_id` on reconnect, mitigating client-side; sticky affinity removes it entirely.) | **MED** | `store.py` 241–242; `websocket.py` ~504 / `http_rpc.py` ~360 (manager_id in connection_info) | Per-instance manager + client-side pinning |
 | P2 | **Autoscaling runs N times.** Each replica runs its own `AutoscalingManager` monitor loop per app, guarded only by a **local** `asyncio.Lock`. N replicas independently decide to scale the same app every 10 s → over-scaling / thrashing. Cooldown timers are per-instance. | **HIGH** | `apps.py` `AutoscalingManager` ~206–263, `_monitor_app_load` ~248–263, `_check_and_scale`, `_last_scale_time`/`_scaling_locks` ~206–212 | No distributed lock / single owner |
-| P3 | **Workspace activity-cleanup race.** Each replica runs a `WorkspaceActivityManager`; N trackers may concurrently unload/delete the same inactive workspace. HDEL is idempotent, but the **unload callbacks** (S3 / artifact cleanup) can race. | **MED** | `workspace.py` `WorkspaceActivityManager` ~139–296, `_cleanup_inactive_workspace` ~256–282 (plain `hexists`→`hdel`, no WATCH/revision) | No leader / no transactional guard |
+| P3 | **Workspace activity-cleanup race.** Each replica runs a `WorkspaceActivityManager`; N trackers may concurrently clean up the same inactive workspace. HDEL is idempotent, but redundant cleanup is wasteful and any heavier unload could race. **Fixed** via a per-workspace `SET NX PX` lock (NOT leader-gate — see §3.1). | **MED** | `workspace.py` `_cleanup_inactive_workspace` | Resolved: transactional per-workspace guard |
 | P4 | **App inactivity-stop fires N times.** Each replica registers its own inactivity tracker per session; multiple replicas may each call `_stop_after_inactive` → stop the app repeatedly. | **MED** | `apps.py` ~2635–2657 | Per-instance tracker; no Redis recheck |
 | P5 | **Worker sessions orphaned on instance death.** Workers hold session state **in-memory**; Redis keeps only metadata. If the instance that launched a worker dies, its sessions are unrecoverable by peers (`worker.stop` raises `SessionNotFound`). | **MED** | `apps.py` worker cache ~587–588; `workers/browser.py` `_sessions` ~88–89, stop ~467 | No lease/heartbeat; stateful workers |
 | P6 | **Per-instance quotas & rate limits.** Per-user / per-workspace connection limits and the WS token-bucket rate limiter are in-memory per replica → effective limits become ≈ ×N; a re-routed client gets a fresh bucket. | **LOW** | `websocket.py` semaphore ~87, rate limiter ~43–63/528–540; `resource_limits.py` counters ~38–172 | Not aggregated across replicas |
@@ -83,14 +83,25 @@ registry. See §5.
 
 ### 3.1 One primitive solves most of the control-plane gaps: a Redis leader lease
 
-P1, P2, P3, and (a future) worker health monitor are all **"exactly-one-runner"**
+P1, P2, and (a future) worker health monitor are **"exactly-one-runner"**
 problems. Introduce a small **distributed leader lease** (Redis `SET key val NX PX=ttl`
 renewed on an interval; value = `server_id`) and gate the singleton work behind
 "am I the leader?":
 
-- **Leader-only loops:** autoscaling monitor (P2), workspace activity cleanup
-  (P3), housekeeping (currently commented out in `store.py`), and any future
-  worker health monitor.
+- **Leader-only loops:** autoscaling monitor (P2), housekeeping (currently
+  commented out in `store.py`), and any future worker health monitor.
+
+> **P3 is NOT leader-gated — implemented with a per-workspace lock instead.**
+> A persistent workspace is registered for activity-cleanup on whichever replica
+> *unloaded* it (`_unload_workspace` → `register_for_cleanup`); under Phase-1
+> sticky affinity that is the replica owning the workspace, which is **not**
+> necessarily the leader. Leader-gating the cleanup would therefore leak any
+> workspace whose owning replica is not the leader. The race (several replicas
+> cleaning the same workspace during failover / non-sticky windows) is instead
+> resolved by a short per-workspace `SET NX PX` lock around
+> `_cleanup_inactive_workspace`: exactly one replica cleans up, whoever fires
+> first, with no leak. (Implemented: `hypha/core/workspace.py`,
+> tests `tests/test_workspace_cleanup_lock.py`.)
 - **Followers** still serve all client traffic, RPC, and service registration —
   they just don't run the singleton background controllers.
 - On leader loss/crash the lease expires (PX TTL) and another replica acquires

--- a/hypha/core/workspace.py
+++ b/hypha/core/workspace.py
@@ -261,6 +261,19 @@ class WorkspaceActivityManager:
             workspace_id: The workspace ID to potentially clean up
         """
         try:
+            # F6 (P3): in a multi-replica deployment several replicas' activity
+            # trackers can fire this callback for the SAME workspace (e.g. during
+            # failover or non-sticky routing). A short per-workspace NX lock makes
+            # exactly one replica perform the cleanup; the rest no-op. A
+            # per-workspace lock (rather than a global leader-gate) is required
+            # here: a persistent workspace is registered for cleanup on whichever
+            # replica unloaded it (see _unload_workspace) — under sticky affinity
+            # that is NOT necessarily the leader, so leader-gating would leak
+            # workspaces that no leader tracks. The lock has no such gap.
+            lock_key = f"ws-cleanup-lock:{workspace_id}"
+            if not await self._redis.set(lock_key, b"1", nx=True, px=30000):
+                return  # another replica is cleaning this workspace up
+
             # Double-check workspace still exists and has no active clients
             if await self._redis.hexists("workspaces", workspace_id):
                 client_keys = await self._workspace_manager._list_client_keys(workspace_id)
@@ -272,12 +285,16 @@ class WorkspaceActivityManager:
                     # Workspace has active clients, reset activity timer
                     logger.debug(f"Workspace {workspace_id} still has active clients, resetting timer")
                     await self.reset_activity(workspace_id)
+                    await self._redis.delete(lock_key)
                     return  # Don't unregister, keep tracking
-            
+
             # Always clean up registration to prevent memory leak
             if workspace_id in self._registrations:
                 del self._registrations[workspace_id]
-            
+
+            # Release the lock; on an exception path it auto-expires via its TTL.
+            await self._redis.delete(lock_key)
+
         except Exception as e:
             logger.error(f"Error cleaning up inactive workspace {workspace_id}: {e}")
 

--- a/tests/test_workspace_cleanup_lock.py
+++ b/tests/test_workspace_cleanup_lock.py
@@ -1,0 +1,97 @@
+"""F6 Phase 1 (P3): per-workspace cleanup lock prevents concurrent multi-replica
+cleanup of the same inactive workspace, without leaking workspaces.
+
+Real fakeredis, no mocks of the system under test (the real
+WorkspaceActivityManager). Minimal tracker/workspace-manager stands-ins supply
+the two collaborators the cleanup callback touches.
+"""
+import pytest
+from fakeredis import aioredis as fakeredis
+
+from hypha.core.workspace import WorkspaceActivityManager
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeTracker:
+    """Non-None tracker so the activity manager is enabled; records reset calls."""
+
+    def __init__(self):
+        self.reset_calls = []
+
+    async def reset_timer(self, entity_id, entity_type="default"):
+        self.reset_calls.append(entity_id)
+
+
+class _FakeWorkspaceManager:
+    def __init__(self, client_keys=None):
+        self._client_keys = client_keys or []
+
+    async def _list_client_keys(self, workspace_id):
+        return self._client_keys
+
+
+def _make_mgr(redis, client_keys=None):
+    return WorkspaceActivityManager(
+        activity_tracker=_FakeTracker(),
+        redis=redis,
+        workspace_manager=_FakeWorkspaceManager(client_keys),
+        inactive_period=300,
+        check_interval=60,
+    )
+
+
+async def test_cleanup_deletes_empty_workspace_and_releases_lock():
+    r = fakeredis.FakeRedis()
+    await r.hset("workspaces", "ws-x", b"{}")
+    mgr = _make_mgr(r, client_keys=[])
+
+    await mgr._cleanup_inactive_workspace("ws-x")
+
+    assert await r.hexists("workspaces", "ws-x") is False  # deleted
+    assert await r.get("ws-cleanup-lock:ws-x") is None  # lock released
+
+
+async def test_cleanup_skips_when_lock_held_by_other_replica():
+    r = fakeredis.FakeRedis()
+    await r.hset("workspaces", "ws-x", b"{}")
+    mgr = _make_mgr(r, client_keys=[])
+
+    # Simulate another replica mid-cleanup holding the per-workspace lock.
+    assert await r.set("ws-cleanup-lock:ws-x", b"1", nx=True, px=30000)
+
+    await mgr._cleanup_inactive_workspace("ws-x")
+    # This replica must NOT delete the workspace while another holds the lock.
+    assert await r.hexists("workspaces", "ws-x") is True
+
+    # Once the lock frees, the retry cleans it up (no leak).
+    await r.delete("ws-cleanup-lock:ws-x")
+    await mgr._cleanup_inactive_workspace("ws-x")
+    assert await r.hexists("workspaces", "ws-x") is False
+
+
+async def test_two_replicas_only_one_deletes():
+    r = fakeredis.FakeRedis()  # shared Redis
+    await r.hset("workspaces", "ws-x", b"{}")
+    a = _make_mgr(r, client_keys=[])
+    b = _make_mgr(r, client_keys=[])
+
+    # Both fire (sequentially in-process); the lock means the first deletes and
+    # the second is a clean no-op — exactly one effective cleanup, no error.
+    await a._cleanup_inactive_workspace("ws-x")
+    await b._cleanup_inactive_workspace("ws-x")
+
+    assert await r.hexists("workspaces", "ws-x") is False
+    assert await r.get("ws-cleanup-lock:ws-x") is None
+
+
+async def test_cleanup_resets_and_does_not_delete_when_clients_present():
+    r = fakeredis.FakeRedis()
+    await r.hset("workspaces", "ws-x", b"{}")
+    mgr = _make_mgr(r, client_keys=["ws-x/client-1"])  # still has a client
+
+    await mgr._cleanup_inactive_workspace("ws-x")
+
+    assert await r.hexists("workspaces", "ws-x") is True  # NOT deleted
+    assert mgr._tracker.reset_calls == ["ws-x"]  # activity timer reset
+    assert await r.get("ws-cleanup-lock:ws-x") is None  # lock released even on this path


### PR DESCRIPTION
## F6 Phase 1 — P3: workspace activity-cleanup race

Prevents several replicas' activity trackers from concurrently cleaning up the **same** inactive workspace, **without leaking workspaces**.

### Change
`_cleanup_inactive_workspace()` now takes a short per-workspace `SET NX PX` lock (`ws-cleanup-lock:{id}`, 30s TTL) before deleting; if another replica holds it, this replica no-ops. Exactly one replica cleans up — whoever fires first. The lock is released on the normal paths and auto-expires via its TTL on error.

### Why a per-workspace lock and **not** a leader-gate
A persistent workspace is registered for activity-cleanup on whichever replica *unloaded* it (`_unload_workspace` → `register_for_cleanup`). Under Phase-1 **sticky affinity** that's the replica owning the workspace — **not** necessarily the leader. Leader-gating the cleanup would therefore **leak** any workspace whose owning replica isn't the leader. The per-workspace lock has no such gap. (This is the design doc's "transactional guard" alternative; doc §3.1/P3 updated to record the decision.)

### Tests (docker-free, fakeredis, no mocks)
- deletes an empty workspace and releases the lock
- skips when the lock is held by another replica, then succeeds on retry (**no leak**)
- two replicas → exactly one effective deletion
- resets the activity timer and keeps the workspace when clients are still present (lock released on this path too)

Single-replica behavior is unchanged (the sole replica always wins the lock). Part of F6 Phase 1 (with #964 Phase 0, #965 Phase 1a); remaining: P1 idempotent startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)