### PR TITLE
feat(f6): per-session lock for app inactivity-stop (Phase 1, P4)

### DIFF
--- a/hypha/apps.py
+++ b/hypha/apps.py
@@ -533,6 +533,22 @@ class ServerAppController:
                 logger.error(f"Error in worker health monitoring: {e}")
                 await asyncio.sleep(60)  # Wait 1 minute before retrying
 
+    @staticmethod
+    async def _acquire_stop_lock(redis, full_client_id: str, ttl_ms: int = 30000) -> bool:
+        """Acquire a short per-session lock so that, in a multi-replica
+        deployment, exactly one replica stops an inactive app (F6/P4).
+
+        Returns True if this replica won the lock and should perform the stop.
+        The lock auto-expires via its TTL; stopping an already-stopped app is a
+        benign no-op (the caller re-checks the session exists), so the lock only
+        needs to cover the brief stop window.
+        """
+        return bool(
+            await redis.set(
+                f"app-stop-lock:{full_client_id}", b"1", nx=True, px=ttl_ms
+            )
+        )
+
     async def _get_session_from_redis(self, full_client_id: str) -> Optional[dict]:
         """Get session data from Redis."""
         try:
@@ -2647,6 +2663,14 @@ class ServerAppController:
             ):
 
                 async def _stop_after_inactive():
+                    # F6 (P4): every replica that registered this session's
+                    # inactivity tracker can fire this callback for the same
+                    # app. A short per-session lock ensures exactly one replica
+                    # performs the stop, instead of several racing on _stop.
+                    if not await self._acquire_stop_lock(
+                        self.store.get_redis(), full_client_id
+                    ):
+                        return  # another replica is stopping this app
                     session_data = await self._get_session_from_redis(full_client_id)
                     if session_data:
                         await self._stop(

--- a/tests/test_app_stop_lock.py
+++ b/tests/test_app_stop_lock.py
@@ -1,0 +1,38 @@
+"""F6/P4: per-session lock so only one replica stops an inactive app.
+
+Docker-free: tests the _acquire_stop_lock primitive directly against a shared
+fakeredis (two replicas → one Redis), without constructing the full controller.
+"""
+import pytest
+from fakeredis import aioredis as fakeredis
+
+from hypha.apps import ServerAppController
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_only_one_replica_acquires_stop_lock():
+    r = fakeredis.FakeRedis()  # shared Redis
+    full_client_id = "ws-x/app-1"
+
+    first = await ServerAppController._acquire_stop_lock(r, full_client_id)
+    second = await ServerAppController._acquire_stop_lock(r, full_client_id)
+
+    assert first is True, "first replica must win the stop lock"
+    assert second is False, "second replica must be blocked (no double-stop)"
+
+
+async def test_different_sessions_do_not_block_each_other():
+    r = fakeredis.FakeRedis()
+    assert await ServerAppController._acquire_stop_lock(r, "ws-x/app-1") is True
+    assert await ServerAppController._acquire_stop_lock(r, "ws-x/app-2") is True
+
+
+async def test_lock_expires_allowing_a_later_stop():
+    r = fakeredis.FakeRedis()
+    fid = "ws-x/app-1"
+    assert await ServerAppController._acquire_stop_lock(r, fid, ttl_ms=50) is True
+    assert await ServerAppController._acquire_stop_lock(r, fid, ttl_ms=50) is False
+    # Simulate TTL expiry by deleting the key (fakeredis time control is coarse).
+    await r.delete(f"app-stop-lock:{fid}")
+    assert await ServerAppController._acquire_stop_lock(r, fid, ttl_ms=50) is True


### PR DESCRIPTION
## F6 Phase 1 — P4: app inactivity-stop race

In a multi-replica deployment several replicas may each register an inactivity tracker for the same app session, so the inactivity callback can fire on each and **race on `_stop`**.

### Change
`_stop_after_inactive` now takes a short per-session lock (`app-stop-lock:{id}`, 30s TTL) via the new `ServerAppController._acquire_stop_lock` staticmethod; only the replica that wins the lock performs the stop. `_stop` is already idempotent (re-checks the session exists), so the lock just removes the brief double-stop window.

**Per-session lock, not a leader-gate** — same reason as P3 (#966): the inactivity tracker is registered on whichever replica started the app, which under sticky affinity isn't necessarily the leader; leader-gating would leave apps that no leader tracks unstopped.

### Tests (docker-free, fakeredis)
`tests/test_app_stop_lock.py` — only one replica acquires the lock; different sessions don't block each other; the lock expires to allow a later stop.

This is the last MED control-plane item; with #964/#965/#966/#967 it completes the leader-/lock-guarding of the control plane for safe N>1. (P5 worker-session recovery + the distributed client registry remain documented Phase-2 work.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)