### PR TITLE
fix(f6): clear cross-pod recently-disconnected cache on re-pin (N>=2 correctness)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -482,6 +482,30 @@ land on the surviving replica).
   timeout-based disconnect detection. Tracked as F4; see amun-ai/hypha (svamp
   reliability audit).
 
+### Multi-Replica: Per-Pod Caches Must Be Invalidated Across Pods (F6)
+
+Any **per-pod in-memory cache keyed by client/peer identity** becomes a
+correctness hazard at N≥2 if it is not invalidated when that client moves pods.
+
+- **Incident (F6, 2026-06-17):** the dead-peer fast-reject in
+  `RedisRPCConnection.emit_message` ("Target peer is not connected") used the
+  per-pod `_recently_disconnected` cache (`core/__init__.py`, 120s TTL, populated
+  on WS disconnect). Correct at N=1; at N≥2 a client that re-pins to a **sibling**
+  pod (rollout / HPA / restart / `upstream-hash-by client_id` re-pin) stays cached
+  as "disconnected" on the **old** pod for the full TTL, so it false-rejects RPCs
+  to a peer that is actually alive elsewhere → dropped RPCs, client disconnects.
+- **Fix:** on (re)connect, the receiving pod broadcasts `client-reconnected`; every
+  pod clears that client from its `_recently_disconnected`
+  (`RedisEventBus.notify_client_connected` / `_on_client_reconnected_event`), wired
+  into **both** the WebSocket and HTTP-streaming connect paths. O(1) per connect —
+  do **not** fix this with a per-message Redis scan (that re-introduces the
+  `redis.keys`/scan-in-hot-path anti-pattern).
+- **Key Lesson:** when validating multi-replica, **test client MIGRATION across
+  pods** (disconnect from A, reconnect to B, then message it via A) — not just
+  stable cross-pod RPC. Sticky/`client_id`-hash affinity does NOT prevent re-pins
+  on topology changes. Tracked as F6; tests in `test_cross_pod_reconnect.py` and
+  `test_multi_replica_integration.py::test_cross_pod_repin_no_false_reject`.
+
 **Critical Pattern (V10-V14)**: When an ID contains a workspace prefix (e.g., `workspace/client_id`), always validate permission on the embedded workspace, not just `context["ws"]`.
 
 ```python

--- a/hypha/core/__init__.py
+++ b/hypha/core/__init__.py
@@ -1213,6 +1213,14 @@ class RedisEventBus:
         # Track recently-disconnected clients for fast dead-peer detection
         self._recently_disconnected = {}  # {client_key: disconnect_timestamp}
         self._disconnected_ttl = 120  # seconds to remember disconnected clients
+        # F6 (multi-replica correctness): when a client (re)connects to ANY pod,
+        # that pod broadcasts so every other pod clears it from its per-pod
+        # recently-disconnected cache. Without this, a client that re-pins to a
+        # sibling pod (rollout / HPA scale / restart) stays wrongly cached as
+        # "disconnected" on the old pod for up to _disconnected_ttl, and the
+        # dead-peer check (RedisRPCConnection) false-rejects messages to a peer
+        # that is actually alive elsewhere ("Target peer is not connected").
+        self.on("client-reconnected", self._on_client_reconnected_event)
         # Ensure latency gauge exists in /metrics even if not updated elsewhere
         try:
             RedisEventBus._pubsub_latency.set(0)
@@ -1344,6 +1352,33 @@ class RedisEventBus:
             del self._recently_disconnected[client_key]
             return False
         return True
+
+    def _on_client_reconnected_event(self, client_key):
+        """Cross-pod 'client-reconnected' broadcast handler: drop the client from
+        this pod's recently-disconnected cache so we stop false-rejecting
+        messages to a peer that has re-pinned to a sibling pod (F6/N>=2)."""
+        if isinstance(client_key, bytes):
+            client_key = client_key.decode("utf-8")
+        self._recently_disconnected.pop(client_key, None)
+
+    async def notify_client_connected(self, workspace: str, client_id: str):
+        """Announce that a client (re)connected to this pod so sibling pods clear
+        it from their recently-disconnected caches (multi-replica correctness).
+
+        Best-effort: a failure here only means a sibling may briefly keep a stale
+        cache entry; it does not affect the connection itself.
+        """
+        client_key = f"{workspace}/{client_id}"
+        # Clear locally too (no-op if absent / already cleared on register).
+        self._recently_disconnected.pop(client_key, None)
+        try:
+            result = self.emit("client-reconnected", client_key)
+            if asyncio.iscoroutine(result) or asyncio.isfuture(result):
+                await result
+        except Exception as e:
+            logger.debug(
+                "Failed to broadcast client-reconnected for %s: %s", client_key, e
+            )
 
     async def cleanup_orphaned_patterns(self):
         """Clean up orphaned patterns that may have accumulated."""

--- a/hypha/http_rpc.py
+++ b/hypha/http_rpc.py
@@ -137,6 +137,14 @@ class HTTPStreamingRPCServer:
 
         conn.on_message(send_to_queue)
 
+        # F6 (multi-replica): announce this client to sibling pods so they clear
+        # any stale recently-disconnected cache entry and don't false-reject
+        # messages to it after a re-pin to this pod.
+        try:
+            await event_bus.notify_client_connected(workspace, client_id)
+        except Exception as e:
+            logger.debug(f"notify_client_connected failed for {connection_key}: {e}")
+
         return conn, queue
 
     async def _remove_connection(self, workspace: str, client_id: str, conn: RedisRPCConnection):

--- a/hypha/websocket.py
+++ b/hypha/websocket.py
@@ -481,6 +481,11 @@ class WebsocketServer:
             _connections_established.inc()  # Monotonic counter, never decrements
             event_bus.on_local(f"unload:{workspace}", force_disconnect)
 
+            # F6 (multi-replica): announce this client to sibling pods so they
+            # clear any stale recently-disconnected cache entry — otherwise, after
+            # a re-pin to this pod, the old pod would false-reject messages to it.
+            await event_bus.notify_client_connected(workspace, client_id)
+
             async def send_bytes(data):
                 try:
                     # Handle both bytes and dict data

--- a/tests/test_cross_pod_reconnect.py
+++ b/tests/test_cross_pod_reconnect.py
@@ -1,0 +1,85 @@
+"""F6 multi-replica correctness: a client re-pinning to a sibling pod must not be
+false-rejected by the old pod's per-pod recently-disconnected cache.
+
+Regression test for the N>=2 prod incident (2026-06-17): the dead-peer check in
+RedisRPCConnection rejected messages to a peer that had moved to another pod,
+because the old pod kept it in `_recently_disconnected` (per-pod, in-memory,
+120s TTL) for the full TTL even though the peer was alive on a sibling pod. The
+fix broadcasts on (re)connect so every pod clears the stale entry.
+
+Docker-free: two RedisEventBus instances share one fakeredis (= two pods on one
+Redis), mirroring tests/test_event_bus_optimization.py.
+"""
+import asyncio
+
+import pytest
+from fakeredis import aioredis as fakeredis
+
+from hypha.core import RedisEventBus
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _make_bus(redis):
+    bus = RedisEventBus(redis)
+    await bus.init()
+    return bus
+
+
+async def test_reconnect_broadcast_clears_sibling_recently_disconnected():
+    redis = fakeredis.FakeRedis.from_url("redis://localhost:9997/1")
+    pod_a = await _make_bus(redis)
+    pod_b = await _make_bus(redis)
+    try:
+        # Pod A saw client X's WS drop -> tracks it as recently disconnected.
+        pod_a.track_recently_disconnected("ws1", "X")
+        assert pod_a.is_recently_disconnected("ws1", "X")
+
+        # Client X re-pins to pod B -> pod B announces the (re)connection.
+        await pod_b.notify_client_connected("ws1", "X")
+
+        # The broadcast propagates over Redis -> pod A clears its stale entry.
+        for _ in range(40):
+            await asyncio.sleep(0.05)
+            if not pod_a.is_recently_disconnected("ws1", "X"):
+                break
+        assert not pod_a.is_recently_disconnected("ws1", "X"), (
+            "old pod must clear recently-disconnected after the client re-pins "
+            "to a sibling pod (otherwise it false-rejects messages to a live peer)"
+        )
+    finally:
+        await pod_a.stop()
+        await pod_b.stop()
+
+
+async def test_genuine_disconnect_stays_cached_for_fast_fail():
+    """A client that does NOT reconnect anywhere must stay cached, so the
+    dead-peer fast-fail still works. A different client's reconnect must not
+    spuriously clear it."""
+    redis = fakeredis.FakeRedis.from_url("redis://localhost:9997/2")
+    pod_a = await _make_bus(redis)
+    pod_b = await _make_bus(redis)
+    try:
+        pod_a.track_recently_disconnected("ws1", "gone")
+        # A DIFFERENT client reconnects elsewhere — must not clear 'gone'.
+        await pod_b.notify_client_connected("ws1", "other")
+        await asyncio.sleep(0.3)
+        assert pod_a.is_recently_disconnected("ws1", "gone"), (
+            "an unrelated reconnect must not clear a genuinely-gone peer"
+        )
+    finally:
+        await pod_a.stop()
+        await pod_b.stop()
+
+
+async def test_local_handler_clears_own_cache():
+    """notify_client_connected also clears the announcing pod's own cache."""
+    redis = fakeredis.FakeRedis.from_url("redis://localhost:9997/3")
+    pod = await _make_bus(redis)
+    try:
+        pod.track_recently_disconnected("ws1", "Z")
+        assert pod.is_recently_disconnected("ws1", "Z")
+        await pod.notify_client_connected("ws1", "Z")
+        assert not pod.is_recently_disconnected("ws1", "Z")
+    finally:
+        await pod.stop()

--- a/tests/test_multi_replica_integration.py
+++ b/tests/test_multi_replica_integration.py
@@ -130,3 +130,67 @@ async def test_cross_replica_service_call(
     await provider.disconnect()
     await caller.disconnect()
     await api.disconnect()
+
+
+async def test_cross_pod_repin_no_false_reject(
+    fastapi_server_redis_1, fastapi_server_redis_2, test_user_token
+):
+    """A peer that re-pins from pod A to pod B must NOT be false-rejected by pod
+    A's stale recently-disconnected cache.
+
+    Regression for the N>=2 prod incident (2026-06-17): pod A kept the migrated
+    client in `_recently_disconnected` (120s TTL) and rejected messages to it
+    with "Target peer is not connected", even though it was alive on pod B. The
+    fix broadcasts on (re)connect so pod A clears the stale entry.
+    """
+    server_a = SERVER_URL_REDIS_1
+    server_b = fastapi_server_redis_2
+
+    admin = await connect_to_server(
+        {"client_id": "repin-admin", "server_url": server_a, "token": test_user_token}
+    )
+    await admin.create_workspace(
+        {"name": "repin-ws", "persistent": True, "owners": ["user1@imjoy.io"]},
+        overwrite=True,
+    )
+    token = await admin.generate_token({"workspace": "repin-ws"})
+
+    # Caller stays on pod A for the whole test.
+    caller = await connect_to_server(
+        {"client_id": "caller", "server_url": server_a, "workspace": "repin-ws",
+         "token": token, "method_timeout": 30}
+    )
+    # Provider 'migrant' starts on pod A and registers a service.
+    provider_a = await connect_to_server(
+        {"client_id": "migrant", "server_url": server_a, "workspace": "repin-ws",
+         "token": token, "method_timeout": 30}
+    )
+    await provider_a.register_service(
+        {"id": "svc", "echo": lambda x: x + 1}, {"overwrite": True}
+    )
+    svc = await caller.get_service("migrant:svc")
+    assert await svc.echo(1) == 2  # works while migrant is on pod A
+
+    # migrant disconnects from pod A -> pod A tracks it as recently-disconnected.
+    await provider_a.disconnect()
+    await asyncio.sleep(2)
+
+    # migrant RE-PINS to pod B with the SAME client_id and re-registers — exactly
+    # the topology-change re-pin that the nginx client_id hash ring does.
+    provider_b = await connect_to_server(
+        {"client_id": "migrant", "server_url": server_b, "workspace": "repin-ws",
+         "token": token, "method_timeout": 30}
+    )
+    await provider_b.register_service(
+        {"id": "svc", "echo": lambda x: x + 1}, {"overwrite": True}
+    )
+    await asyncio.sleep(1)  # let the reconnect broadcast + re-registration settle
+
+    # Caller on pod A calls migrant's service. Within the 120s TTL window, the old
+    # behavior would false-reject ("not connected"); with the fix it reaches pod B.
+    svc2 = await caller.get_service("migrant:svc")
+    assert await svc2.echo(10) == 11
+
+    await provider_b.disconnect()
+    await caller.disconnect()
+    await admin.disconnect()


### PR DESCRIPTION
## Prod incident (2026-06-17) — multi-replica false-reject

With hypha-server at **N≥2**, the dead-peer check (`RedisRPCConnection.emit_message`, "Target peer is not connected") **false-rejected RPCs to a peer that had re-pinned to a sibling pod**. The per-pod in-memory `_recently_disconnected` cache (120s TTL, populated on WS disconnect) is correct at N=1, but at N≥2 a client moving pods (rollout / HPA scale / restart / the nginx `client_id` hash ring re-pinning on any topology change) leaves the **old pod** wrongly believing it is gone for the full TTL — dropping RPCs to a live peer. 64 such errors in 60min; the rollout was reverted to N=1.

This is the gap my F6 Phase 1 missed — I under-rated cross-pod dead-peer detection (logged as "slower detection", LOW) and deferred the client-migration test that would have caught it.

## Root cause
`_recently_disconnected` is **per-pod** and never invalidated when the client reconnects to a **different** pod.

## Fix
On client (re)connect to any pod, that pod broadcasts a `client-reconnected` event; every pod clears that client from its `_recently_disconnected` cache (`RedisEventBus.notify_client_connected` + `_on_client_reconnected_event`). Wired into **both** connect paths — WebSocket and HTTP-streaming. This collapses the false-reject window from the 120s TTL to **sub-second** (pub/sub propagation), with **no per-message cost** (no hot-path Redis scan) and **no change to the dead-peer fast-fail** for genuinely-gone peers.

## Tests
- **`test_cross_pod_reconnect.py`** (docker-free, two event buses + one fakeredis): re-pin broadcast clears a sibling's stale cache; a genuine disconnect stays cached (fast-fail preserved); an unrelated reconnect does not over-clear.
- **`test_multi_replica_integration.py::test_cross_pod_repin_no_false_reject`** (two live servers + one real Redis): a provider re-pinning from pod A→B is reachable from a caller on pod A (was false-rejected before).
- Existing **`test_peer_not_found.py`** still passes — genuinely-gone peers still error immediately.

**Required before hypha-server can safely run N≥2 again.** After this merges I'll cut a release and notify the kth-k8s agent (currently halted at N=1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)