### PR TITLE
fix(f6): drop fire-and-forget messages to gone peers (reject-storm, N>=2)

### DIFF
--- a/hypha/core/__init__.py
+++ b/hypha/core/__init__.py
@@ -871,7 +871,7 @@ class RedisRPCConnection:
 
         packed_message = msgpack.packb(message) + data[pos:]
 
-        # Dead-peer detection: reject messages to recently-disconnected clients
+        # Dead-peer detection: handle messages to recently-disconnected clients.
         # Only uses the local recently-disconnected cache (fast, no Redis lookup).
         # This catches the common case: client was on THIS server and disconnected.
         if target_id and "*" not in target_id and "/" in target_id:
@@ -881,9 +881,23 @@ class RedisRPCConnection:
             ) and self._event_bus.is_recently_disconnected(
                 workspace_part, client_part
             ):
-                raise Exception(
-                    f"Target peer {target_id} is not connected"
-                )
+                # Fast-fail ONLY primary calls awaiting a response — they carry a
+                # "session" (set when with_promise; see hypha_rpc rpc.py). Raising
+                # lets the caller's await reject immediately instead of timing out.
+                #
+                # Fire-and-forget traffic (results / rejects / callback
+                # invocations — no "session") to a now-gone peer must be a SILENT
+                # no-op. Otherwise, when a client with in-flight RPCs disconnects,
+                # the server cleans up its pending promises by routing reject/
+                # result callbacks back to the (gone) client; each would raise
+                # "Target peer is not connected", producing a reject-STORM that
+                # at N>=2 churns the client into a reconnect loop. (F6 incident #2,
+                # 2026-06-17; distinct from the migration fix in #969.)
+                if message.get("session"):
+                    raise Exception(
+                        f"Target peer {target_id} is not connected"
+                    )
+                return  # undeliverable fire-and-forget message — drop silently
 
         # Use Redis event bus routing (local handlers are attached there)
         await self._event_bus.emit(f"{target_id}:msg", packed_message)

--- a/tests/test_dead_peer_reject_storm.py
+++ b/tests/test_dead_peer_reject_storm.py
@@ -1,0 +1,87 @@
+"""F6 incident #2 (2026-06-17): reject-storm to a disconnected peer at N>=2.
+
+When a client with in-flight RPCs disconnects, the server cleans up its pending
+promises by routing reject/result callbacks back to the (now-gone) client. Each
+such fire-and-forget message hit the dead-peer check and RAISED "Target peer is
+not connected" — a storm (52 per gone client observed) that churned the client
+into a reconnect loop at N>=2.
+
+Fix: the dead-peer check fast-fails ONLY primary calls awaiting a response
+(which carry a "session"); fire-and-forget traffic (no "session") to a gone peer
+is dropped silently. Distinct from the cross-pod migration fix (#969).
+
+Docker-free: drives RedisRPCConnection.emit_message directly with a minimal
+fake event bus that reports the target as recently-disconnected.
+"""
+import msgpack
+import pytest
+
+from hypha.core import RedisRPCConnection
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeBus:
+    def __init__(self):
+        self.emitted = []
+
+    def is_local_client(self, ws, client_id):
+        return False  # target is not on this pod
+
+    def is_recently_disconnected(self, ws, client_id):
+        return True  # target recently disconnected from this pod
+
+    async def emit(self, name, data):
+        self.emitted.append(name)
+
+
+def _conn(bus):
+    c = RedisRPCConnection.__new__(RedisRPCConnection)
+    c._workspace = "ws1"
+    c._client_id = "sender"
+    c._readonly = False
+    c._user_info = {}
+    c._event_bus = bus
+    c._stop = False
+    return c
+
+
+async def test_primary_call_to_gone_peer_fast_fails():
+    """A primary call (has 'session') to a gone peer must raise so the caller's
+    await fails fast instead of timing out (preserves issue #868 behavior)."""
+    bus = _FakeBus()
+    conn = _conn(bus)
+    data = msgpack.packb(
+        {"to": "ws1/gone", "type": "method", "method": "do", "session": "s1"}
+    )
+    with pytest.raises(Exception, match="not connected"):
+        await conn.emit_message(data)
+    assert bus.emitted == [], "must not deliver to a gone peer"
+
+
+async def test_fire_and_forget_to_gone_peer_drops_silently():
+    """A fire-and-forget message (no 'session' — e.g. a reject/result callback
+    to a gone caller) must be dropped silently, NOT raise. This is the fix for
+    the reject-storm."""
+    bus = _FakeBus()
+    conn = _conn(bus)
+    data = msgpack.packb(
+        {"to": "ws1/gone", "type": "method", "method": "reject"}  # no session
+    )
+    # Must NOT raise (no storm) ...
+    await conn.emit_message(data)
+    # ... and must not be routed to the gone peer.
+    assert bus.emitted == []
+
+
+async def test_many_rejects_to_gone_peer_no_storm():
+    """Simulate the cleanup storm: many fire-and-forget rejects to a gone client
+    — none should raise."""
+    bus = _FakeBus()
+    conn = _conn(bus)
+    for i in range(52):
+        data = msgpack.packb(
+            {"to": "ws1/gone", "type": "method", "method": f"cb{i}"}
+        )
+        await conn.emit_message(data)  # no raise on any of them
+    assert bus.emitted == []

--- a/tests/test_multi_replica_integration.py
+++ b/tests/test_multi_replica_integration.py
@@ -194,3 +194,81 @@ async def test_cross_pod_repin_no_false_reject(
     await provider_b.disconnect()
     await caller.disconnect()
     await admin.disconnect()
+
+
+async def test_n2_mid_rpc_disconnect_churn_stays_healthy(
+    fastapi_server_redis_1, fastapi_server_redis_2, test_user_token
+):
+    """Simulate the N>=2 incident pattern end-to-end: clients connect, start
+    in-flight RPCs, then disconnect MID-CALL (repeatedly), while stable cross-pod
+    traffic continues. The cluster must stay healthy — the reject-storm (incident
+    #2) must not disrupt stable clients, and fresh clients must reconnect and call
+    cleanly afterward. This is the 'kill a client mid-RPC' acceptance case that
+    neither the re-pin test nor a graceful pod-delete covers.
+    """
+    server_a = SERVER_URL_REDIS_1
+    server_b = fastapi_server_redis_2
+
+    admin = await connect_to_server(
+        {"client_id": "churn-admin", "server_url": server_a, "token": test_user_token}
+    )
+    await admin.create_workspace(
+        {"name": "churn-ws", "persistent": True, "owners": ["user1@imjoy.io"]},
+        overwrite=True,
+    )
+    token = await admin.generate_token({"workspace": "churn-ws"})
+
+    # Provider with a slow method on pod A (so calls are genuinely in-flight when
+    # a churner disconnects, and the provider holds the churner's reject callback
+    # on the same pod the churner hashes to).
+    async def slow(x):
+        await asyncio.sleep(0.5)
+        return x * 2
+
+    provider = await connect_to_server(
+        {"client_id": "provider", "server_url": server_a, "workspace": "churn-ws",
+         "token": token, "method_timeout": 30}
+    )
+    await provider.register_service(
+        {"id": "svc",
+         "config": {"visibility": "public", "require_context": False},
+         "slow": slow}
+    )
+
+    # Stable caller on pod B (cross-pod) — must succeed before, during, and after.
+    stable = await connect_to_server(
+        {"client_id": "stable", "server_url": server_b, "workspace": "churn-ws",
+         "token": token, "method_timeout": 30}
+    )
+    ssvc = await stable.get_service("provider:svc")
+    assert await ssvc.slow(21) == 42
+
+    # Churn: clients on pod A start an in-flight call, then disconnect mid-RPC.
+    for i in range(10):
+        churner = await connect_to_server(
+            {"client_id": f"churner-{i}", "server_url": server_a,
+             "workspace": "churn-ws", "token": token, "method_timeout": 30}
+        )
+        csvc = await churner.get_service("provider:svc")
+        fut = asyncio.ensure_future(csvc.slow(i))  # in-flight (0.5s); not awaited
+        await asyncio.sleep(0.05)  # let the call dispatch before we cut the client
+        await churner.disconnect()  # disconnect MID-RPC -> server rejects pending
+        fut.cancel()
+
+    # The stable cross-pod caller must keep working through/after the churn — i.e.
+    # the reject-storm fallout did not disrupt the cluster.
+    for _ in range(5):
+        assert await ssvc.slow(5) == 10
+
+    # And a fresh client reconnects and calls cleanly (no reconnect-loop fallout).
+    fresh = await connect_to_server(
+        {"client_id": "fresh", "server_url": server_a, "workspace": "churn-ws",
+         "token": token, "method_timeout": 30}
+    )
+    fsvc = await fresh.get_service("provider:svc")
+    assert await fsvc.slow(8) == 16
+
+    await fresh.disconnect()
+    await stable.disconnect()
+    await provider.disconnect()
+    await admin.disconnect()


### PR DESCRIPTION
## Second N≥2 incident (2026-06-17) — reject-storm

Distinct from the cross-pod migration fix (#969). When a client with in-flight RPCs disconnects, the server cleans up its pending promises by routing reject/result callbacks back to the **now-gone client**. Each hit the dead-peer check in `RedisRPCConnection.emit_message` and **raised** `"Target peer is not connected"` — a storm (52 per gone client, ~100/2min on the busy pod) that churned the client into a reconnect loop at N≥2. At N=1 the same workload is stable.

This is the gap that re-broke the N=3 rollout on 0.21.88 even with #969 in place.

## Root cause
The dead-peer check raised for **any** message to a recently-disconnected client, including **fire-and-forget** result/reject/callback traffic where nothing awaits delivery — so raising only produced a log-storm + connection churn, never a useful fast-fail.

## Fix
Fast-fail (raise) **only** primary calls awaiting a response — they carry a `"session"` (set when `with_promise`; `hypha_rpc/rpc.py:523`, visible in the first message segment). Fire-and-forget messages (no `"session"`) to a gone peer are **dropped silently**. This preserves the issue-#868 fast-fail for real calls while eliminating the cleanup reject-storm.

## Tests
- **`test_dead_peer_reject_storm.py`** (docker-free): a primary call to a gone peer raises; a fire-and-forget message drops silently; 52 rejects produce no storm.
- Existing **`test_peer_not_found.py`** still passes (real fast-fail) ✅
- **`test_cross_pod_reconnect.py`** (#969 migration fix) still passes ✅

Required **with #969** before hypha-server can run N≥2. Prod stays N=1 until this ships and is validated against the disconnect-with-in-flight-RPCs scenario. After merge I'll cut a release and clear the kth-k8s agent to retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)