### PR TITLE
fix(git): release pack memory after each request (malloc_trim + arena tuning)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,14 @@ RUN useradd -u 8877 hypha && \
     chown -R hypha:hypha /.cache && \
     chown -R hypha:hypha /opt/venv
 
+# glibc malloc tuning: cap per-thread (secondary) arenas and lower the main
+# arena's trim threshold so freed memory is returned to the OS more readily.
+# This halves the churn from git's whole-pack buffering; combined with the
+# explicit malloc_trim(0) after each git request (hypha/git/http.py) it keeps
+# RSS from ratcheting to OOM under repeated/concurrent large clones/pushes.
+ENV MALLOC_ARENA_MAX=2
+ENV MALLOC_TRIM_THRESHOLD_=131072
+
 # Switch to non-root user
 USER hypha
 

--- a/hypha/git/http.py
+++ b/hypha/git/http.py
@@ -40,6 +40,32 @@ from hypha.git.repo import S3GitRepo
 logger = logging.getLogger(__name__)
 
 
+def _malloc_trim():
+    """Return freed heap memory to the OS (glibc only; no-op elsewhere).
+
+    Git clone/push buffers whole packs (request body, the generated pack
+    BytesIO, the joined response) — hundreds of MB per op. Python frees those
+    promptly, but glibc retains the freed memory in per-thread (secondary)
+    arenas and does NOT auto-return it; only an explicit malloc_trim(0) does.
+    Under repeated/concurrent large git ops this retention ratchets RSS up to
+    OOM (measured on prod: malloc_trim reclaimed ~1-1.6GB). We call this after
+    each git request (see cleanup_repo) to release the pack memory immediately.
+    On non-glibc platforms (macOS dev, musl) malloc_trim is unavailable -> no-op.
+    """
+    import platform
+
+    if platform.system() != "Linux":
+        return
+    try:
+        import ctypes
+
+        libc = ctypes.CDLL("libc.so.6", use_errno=False)
+        if hasattr(libc, "malloc_trim"):
+            libc.malloc_trim(0)
+    except (OSError, AttributeError) as e:  # pragma: no cover - platform dependent
+        logger.debug(f"malloc_trim unavailable: {e}")
+
+
 async def cleanup_repo(repo):
     """Clean up resources associated with a Git repository.
 
@@ -47,6 +73,26 @@ async def cleanup_repo(repo):
     when getting the repo from artifact_integration.
     """
     try:
+        # Release the loaded pack/index buffers immediately rather than waiting
+        # for GC. Each git request builds a fresh per-request object store whose
+        # S3Pack._ensure_loaded() reads the entire .pack and .idx into resident
+        # bytes (_pack_data/_index_data) — multi-hundred-MB for a large repo.
+        # Under concurrent git load these per-request spikes overlap and ratchet
+        # RSS up to OOM if freeing is left to GC. object_store.close() clears the
+        # _pack_cache and drops those buffers now.
+        if getattr(repo, '_object_store', None) is not None:
+            try:
+                repo._object_store.close()
+                logger.debug("Git repo: object store closed (pack buffers released)")
+            except Exception as e:
+                logger.warning(f"Error closing object store: {e}")
+
+        # Return the freed pack memory to the OS now. close() frees the bytes in
+        # Python, but glibc holds them in secondary (per-thread) arenas and won't
+        # auto-return them — only an explicit malloc_trim(0) does. Without this,
+        # repeated/concurrent large git ops ratchet RSS up to OOM. glibc-only.
+        _malloc_trim()
+
         # Close S3 client if it was stored on the repo
         if hasattr(repo, '_s3_client_context') and repo._s3_client_context:
             try:


### PR DESCRIPTION
## Summary
Fixes the production OOM root cause (also going into the **0.21.93** hotfix for the hypha-dev → prod path). Diagnosed live on prod: `gc.collect()` freed 0, but `malloc_trim(0)` reclaimed ~1–1.6GB.

Git clone/push buffer whole packs in memory (request body + generated-pack `BytesIO` + joined response, ~6–7× repo size). Python frees them promptly, but **glibc retains the freed memory in per-thread (secondary) arenas** and never auto-returns it → under repeated/concurrent large git ops, RSS ratchets to OOM. (`_repo_cache` is dead code, ruled out.)

## Fix (retention/ratchet)
- `cleanup_repo` now closes the per-request object store **and** calls an explicit `malloc_trim(0)` (glibc-only; no-op on macOS/musl) after each git request → returns the freed pack memory to the OS immediately.
- Bake `MALLOC_ARENA_MAX=2` + `MALLOC_TRIM_THRESHOLD_` into the image (halves churn; arena-cap alone is insufficient — measured: trim still reclaimed ~1GB with it on).

## Scope / honesty
- Fixes the **retention ratchet** (the observed slow 15–20min climb to OOM).
- Does **NOT** fix the transient **peak** during concurrent large clones (the whole-pack buffering) — that needs a **streaming** rewrite and/or a git concurrency cap (follow-up, to be sized from a Linux measurement in hypha-dev).
- glibc behavior is only validatable on Linux (the macOS dev harness uses a different allocator) — validated under load on hypha-dev.

Functional git tests pass (39 passed, 2 skipped). Memory behavior validated on Linux via the hypha-dev deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)