### PR TITLE
fix(memory): periodic malloc_trim to bound glibc-arena RSS plateau

### DIFF
--- a/hypha/core/store.py
+++ b/hypha/core/store.py
@@ -360,6 +360,7 @@ class RedisStore:
         self._tracker = None
         self._tracker_task = None
         self._leader_lease = None
+        self._malloc_trim_task = None
         # self._house_keeping_task = None
 
         self._shared_anonymous_user = None
@@ -537,6 +538,44 @@ class RedisStore:
                         logger.exception(f"Error in housekeeping {workspace.id}: {e}")
         except Exception as exp:
             logger.error(f"Failed to run housekeeping task, error: {exp}")
+
+    async def _periodic_malloc_trim(self):
+        """Periodically return glibc-retained free memory to the OS.
+
+        glibc keeps memory freed on worker threads in per-thread arenas and does
+        not auto-return it, so RSS plateaus well above the live working set. An
+        explicit malloc_trim(0) returns it. Interval via HYPHA_MALLOC_TRIM_INTERVAL
+        (seconds, default 60). No-op on non-glibc platforms (macOS/musl).
+        """
+        import platform
+
+        if platform.system() != "Linux":
+            return
+        try:
+            import ctypes
+
+            libc = ctypes.CDLL("libc.so.6", use_errno=False)
+            if not hasattr(libc, "malloc_trim"):
+                return
+        except (OSError, AttributeError) as e:
+            logger.debug(f"malloc_trim unavailable, skipping periodic trim: {e}")
+            return
+
+        try:
+            interval = float(os.environ.get("HYPHA_MALLOC_TRIM_INTERVAL", "60"))
+        except ValueError:
+            interval = 60.0
+        if interval <= 0:
+            return
+        logger.info(f"Periodic malloc_trim enabled (every {interval:.0f}s)")
+        while True:
+            try:
+                await asyncio.sleep(interval)
+                libc.malloc_trim(0)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.debug(f"Periodic malloc_trim error: {e}")
 
     async def upgrade(self):
         """Upgrade the store."""
@@ -1003,6 +1042,16 @@ class RedisStore:
         await self.get_event_bus().emit_local("startup")
         servers = await self.list_servers()
         # self._house_keeping_task = asyncio.create_task(self.housekeeping())
+
+        # Periodically return freed heap memory to the OS (glibc only). The
+        # server frees lots of short-lived buffers on worker threads (request
+        # handling, RPC, artifact ops); glibc keeps that freed memory in
+        # per-thread arenas and never auto-returns it, so RSS plateaus far above
+        # the live working set (measured on prod: malloc_trim reclaimed ~1.3GB
+        # of a 2.1GB RSS, gc freed 0). The per-request malloc_trim in the git
+        # path only covers git ops; this loop bounds the steady-state plateau
+        # for all traffic. No-op on non-glibc platforms.
+        self._malloc_trim_task = asyncio.create_task(self._periodic_malloc_trim())
 
         logger.info("Server initialized with server id: %s", self._server_id)
         logger.info("Currently connected hypha servers: %s", servers)
@@ -1486,6 +1535,13 @@ class RedisStore:
                 await self._leader_lease.stop()
             except Exception as e:
                 logger.warning(f"Error stopping leader lease: {e}")
+
+        if self._malloc_trim_task:
+            self._malloc_trim_task.cancel()
+            try:
+                await self._malloc_trim_task
+            except asyncio.CancelledError:
+                pass
 
         if self._tracker_task:
             self._tracker_task.cancel()

--- a/tests/test_malloc_trim.py
+++ b/tests/test_malloc_trim.py
@@ -1,0 +1,68 @@
+"""Periodic malloc_trim background task lifecycle.
+
+The server starts a periodic malloc_trim(0) loop to return glibc-retained free
+memory to the OS (prod RSS plateaued ~2.1GB of which ~1.3GB was reclaimable
+glibc-arena free memory, not live). This test verifies the task is started on
+init and cancelled cleanly on teardown, and that the trim coroutine is safe on
+any platform (it is a no-op off glibc/Linux).
+
+Docker-free: RedisStore on fakeredis.
+"""
+import asyncio
+
+import pytest
+
+from hypha.core.store import RedisStore
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_malloc_trim_task_started_and_cancelled():
+    store = RedisStore(None, redis_uri=None)
+    await store.init(reset_redis=True)
+    try:
+        # The task is created on init regardless of platform (the coroutine
+        # itself no-ops off glibc).
+        assert store._malloc_trim_task is not None
+    finally:
+        await store.teardown()
+    # After teardown the task must be finished (cancelled or completed), not
+    # left running.
+    assert store._malloc_trim_task.done()
+
+
+async def test_periodic_malloc_trim_coroutine_is_safe():
+    """The trim coroutine must never raise (no-op off glibc; trims on glibc)."""
+    store = RedisStore(None, redis_uri=None)
+    # Run the loop body briefly with a tiny interval, then cancel — it must
+    # exit cleanly via CancelledError without surfacing any other error.
+    import os
+
+    os.environ["HYPHA_MALLOC_TRIM_INTERVAL"] = "0.05"
+    try:
+        task = asyncio.create_task(store._periodic_malloc_trim())
+        await asyncio.sleep(0.2)
+        if task.done():
+            # Off glibc (e.g. macOS dev) the loop returns at the platform guard
+            # — it must have completed without raising.
+            assert task.exception() is None
+        else:
+            # On glibc (Linux/CI) it loops until cancelled.
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+    finally:
+        os.environ.pop("HYPHA_MALLOC_TRIM_INTERVAL", None)
+
+
+async def test_malloc_trim_interval_zero_disables():
+    """HYPHA_MALLOC_TRIM_INTERVAL<=0 returns immediately (disabled)."""
+    import os
+
+    store = RedisStore(None, redis_uri=None)
+    os.environ["HYPHA_MALLOC_TRIM_INTERVAL"] = "0"
+    try:
+        # Should return promptly without needing cancellation.
+        await asyncio.wait_for(store._periodic_malloc_trim(), timeout=2)
+    finally:
+        os.environ.pop("HYPHA_MALLOC_TRIM_INTERVAL", None)


### PR DESCRIPTION
## Summary
Follow-up to the per-request git trim (#975). A **live prod diagnostic** on 0.21.93 showed RSS plateauing ~2.1GB, of which `malloc_trim(0)` reclaimed **~1.3GB** (`gc.collect()` freed 0; normal ~394k object graph; threads/FDs stable). So it's **glibc-arena-retained *free* memory, not a leak** — but the per-request git trim only fires on git ops, so memory freed by general request handling (RPC, artifact ops) accumulates in per-thread arenas and is never auto-returned → slow climb (~1.82→2.12GB/20min).

## Fix
Periodic `malloc_trim(0)` background task (`RedisStore._periodic_malloc_trim`, started in `init` / cancelled in `teardown`), interval via `HYPHA_MALLOC_TRIM_INTERVAL` (default 60s), **glibc-only** (no-op on macOS/musl). Bounds steady-state RSS toward the ~850MB live working set regardless of traffic mix. The per-request git trim stays for immediate relief of multi-GB git spikes.

## Tests
`tests/test_malloc_trim.py` — task lifecycle (started/cancelled) + coroutine safety, docker-free (3 passed).

Memory behavior validated on Linux (hypha-dev / prod), since macOS uses a different allocator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)