### PR TITLE
feat(apps): HYPHA_DISABLE_INPROCESS_BROWSER_WORKER to run API pod browser-free

### DIFF
--- a/hypha/server.py
+++ b/hypha/server.py
@@ -133,8 +133,28 @@ def start_builtin_services(
         from hypha.apps import ServerAppController
         from hypha.workers import BrowserWorker
 
-        browser_worker = BrowserWorker(in_docker=args.in_docker)
-        store.register_public_service(browser_worker.get_worker_service())
+        # The in-process browser worker spawns headless Chromium as children of
+        # this server process. On a memory-limited pod that is the dominant OOM
+        # risk (each session ~300-500MB), and a reconnection storm that respawns
+        # browser apps can crash-loop the API server. Set
+        # HYPHA_DISABLE_INPROCESS_BROWSER_WORKER=true to keep the server-apps
+        # control plane here but run NO browsers in-process — browser apps then
+        # route to a dedicated browser-worker pod (python -m hypha.workers.browser
+        # registered with public visibility), keeping Chromium memory off the API
+        # pod. Worker selection can otherwise route to EITHER worker, so disabling
+        # the in-process one is required for a clean dedicated-worker cutover.
+        _disable_inproc_browser = os.environ.get(
+            "HYPHA_DISABLE_INPROCESS_BROWSER_WORKER", ""
+        ).lower() in ("1", "true", "yes")
+        if _disable_inproc_browser:
+            logger.info(
+                "In-process browser worker DISABLED "
+                "(HYPHA_DISABLE_INPROCESS_BROWSER_WORKER) — browser apps must "
+                "route to a dedicated browser-worker pod"
+            )
+        else:
+            browser_worker = BrowserWorker(in_docker=args.in_docker)
+            store.register_public_service(browser_worker.get_worker_service())
         ServerAppController(
             store,
             port=args.port,


### PR DESCRIPTION
## Why
Prod OOM crash-loop root cause (38 restarts, ~3-4min each, peak ~7.3GB/8G): the **in-process browser worker** spawns headless Chromium as children of the API server; a reconnection storm respawning browser apps bursts memory past the cgroup limit → OOM → restart → storm → repeat (which disconnects all clients, e.g. svamp). Immediate mitigation was `HYPHA_MAX_BROWSER_SESSIONS=2` (broke the loop). This is the **structural** enablement.

## What
`HYPHA_DISABLE_INPROCESS_BROWSER_WORKER=true` keeps the server-apps **control plane** on the API pod but registers **no in-process browser worker** → browser apps route to a **dedicated browser-worker pod** (`python -m hypha.workers.browser`, public visibility, own memory limit), keeping Chromium memory off the memory-limited API pod. Required for a clean dedicated-worker cutover, since worker selection could otherwise route to either worker.

## Scope
One conditional around the in-process `BrowserWorker` registration in `hypha/server.py` (under `--enable-server-apps`). No behavior change unless the env is set. Pairs with a dedicated browser-worker Deployment on the infra side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)