### PR TITLE
fix(artifact): honor parent-collection contributor permissions for writes

### DIFF
--- a/hypha/artifact.py
+++ b/hypha/artifact.py
@@ -2535,11 +2535,31 @@ class ArtifactController:
         if artifact_permissions:
             for perm in artifact_permissions:
                 if not await self._check_permissions(artifact, user_info, perm):
-                    # Try parent as fallback for read operations
-                    if perm in ["read", "list", "get_file", "list_files", "get_vector", "list_vectors", "search_vectors"]:
-                        if parent_artifact and await self._check_permissions(parent_artifact, user_info, perm):
-                            continue  # Permission granted through parent
-                    
+                    # Fall back to the PARENT COLLECTION's permissions for the same
+                    # operation. A child artifact inherits its collection's grants, so
+                    # a collection configured for contributors (e.g. "@": ["commit",
+                    # "put_file", "edit", ...]) lets those users write its children with
+                    # their OWN token — no per-artifact grant and no workspace-owner
+                    # token needed. This mirrors the read fallback and extends it to
+                    # writes (read/read_write tier). The parent's permission LIST is the
+                    # explicit control surface: a collection granting only "@": "r" still
+                    # denies writes (no write op is listed). ADMIN-level operations
+                    # (delete/publish/get_secret/reset_stats) deliberately do NOT inherit
+                    # via collection membership — they still require the artifact's own
+                    # grant or workspace admin. Previously only read-like ops fell back,
+                    # so collection write grants were silently ignored for commit/
+                    # put_file/edit, forcing a workspace-owner token (the ri-scale
+                    # contributor symptom).
+                    # NOTE: UserPermission is a str-Enum (read="r", read_write="rw",
+                    # admin="a") whose ordering is lexicographic, so a numeric "<="
+                    # comparison is unsafe — exclude admin explicitly instead.
+                    perm_level = operation_map.get(perm, UserPermission.read_write)
+                    if perm_level != UserPermission.admin:
+                        if parent_artifact and await self._check_permissions(
+                            parent_artifact, user_info, perm
+                        ):
+                            continue  # Permission granted through the parent collection
+
                     # Check workspace-level permission as final fallback
                     # Workspace owners always have highest permission
                     if not user_info.check_permission(artifact.workspace, operation_map.get(perm, UserPermission.read_write)):

--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -12094,3 +12094,114 @@ async def test_wildcard_artifact_scoped_token(
     await artifact_manager.delete(artifact_id=dataset3_2.id)
     await artifact_manager.delete(artifact_id=collection.id)
     await api.disconnect()
+
+
+async def test_collection_contributor_write_inheritance(
+    minio_server, fastapi_server, test_user_token, test_user_token_2
+):
+    """A non-member contributor can WRITE a child artifact when the parent COLLECTION
+    grants the write (e.g. ``"@": [..,"edit","commit","put_file"]``) — with their OWN
+    token, no per-artifact grant and no workspace-owner token. ADMIN ops (delete) do
+    NOT inherit via collection membership.
+
+    Regression for the ri-scale git-push contributor symptom: write operations must
+    fall back to the parent collection's permissions, mirroring reads. Before the fix
+    only read-like ops fell back, so a contributor whose grant came solely from the
+    collection was denied writes and forced to use a workspace-owner token. See
+    ``hypha/artifact.py::_get_artifact_with_permission``.
+    """
+    # user_1 owns the collection AND the child, so the child's own permissions are just
+    # {user_1: "*"} — user_2 is neither the creator nor explicitly granted on the child.
+    api1 = await connect_to_server(
+        {"name": "u1", "server_url": SERVER_URL, "token": test_user_token}
+    )
+    am1 = await api1.get_service("public/artifact-manager")
+
+    collection = await am1.create(
+        type="collection",
+        manifest={"name": "Contributor Collection"},
+        config={
+            "permissions": {
+                # authenticated users get a contributor WRITE surface via the collection
+                "@": [
+                    "read",
+                    "list",
+                    "get_file",
+                    "list_files",
+                    "edit",
+                    "commit",
+                    "put_file",
+                ],
+            }
+        },
+    )
+    child = await am1.create(
+        parent_id=collection.id,
+        manifest={"name": "contributor-child"},
+        version="stage",
+    )
+    await am1.commit(artifact_id=child.id)
+
+    # user_2: a DIFFERENT authenticated user, NOT a member of user_1's workspace,
+    # NOT the creator, NOT in the child's own permissions.
+    api2 = await connect_to_server(
+        {"name": "u2", "server_url": SERVER_URL, "token": test_user_token_2}
+    )
+    am2 = await api2.get_service("public/artifact-manager")
+
+    # WRITE via the collection's "@" grant: edit(stage) -> put_file -> commit all succeed.
+    await am2.edit(artifact_id=child.id, version="stage")
+    put_url = await am2.put_file(artifact_id=child.id, file_path="weights.txt")
+    async with httpx.AsyncClient(timeout=20) as client:
+        response = await client.put(put_url, data="contributor upload")
+        assert response.status_code == 200
+    await am2.commit(artifact_id=child.id)
+
+    files = await am2.list_files(artifact_id=child.id)
+    assert any(f["name"] == "weights.txt" for f in files)
+
+    # ADMIN ops do NOT inherit via collection membership: user_2 cannot delete the child.
+    with pytest.raises(Exception, match=r".*permission.*delete.*"):
+        await am2.delete(artifact_id=child.id)
+
+    # owner cleanup
+    await am1.delete(artifact_id=child.id)
+    await am1.delete(artifact_id=collection.id)
+    await api1.disconnect()
+    await api2.disconnect()
+
+
+async def test_collection_read_only_denies_contributor_writes(
+    minio_server, fastapi_server, test_user_token, test_user_token_2
+):
+    """A read-only collection (``"@": "r"``) must STILL deny non-member writes — the
+    write fallback grants only the operations the collection EXPLICITLY lists. Guards
+    against the contributor-write fix over-broadening collection-read into
+    collection-write."""
+    api1 = await connect_to_server(
+        {"name": "u1", "server_url": SERVER_URL, "token": test_user_token}
+    )
+    am1 = await api1.get_service("public/artifact-manager")
+    collection = await am1.create(
+        type="collection",
+        manifest={"name": "Read-only Collection"},
+        config={"permissions": {"@": "r"}},
+    )
+    child = await am1.create(
+        parent_id=collection.id, manifest={"name": "ro-child"}, version="stage"
+    )
+    await am1.commit(artifact_id=child.id)
+
+    api2 = await connect_to_server(
+        {"name": "u2", "server_url": SERVER_URL, "token": test_user_token_2}
+    )
+    am2 = await api2.get_service("public/artifact-manager")
+    # read works (collection grants read); write must be denied (no write op listed).
+    await am2.read(artifact_id=child.id)
+    with pytest.raises(Exception, match=r".*permission.*"):
+        await am2.edit(artifact_id=child.id, version="stage")
+
+    await am1.delete(artifact_id=child.id)
+    await am1.delete(artifact_id=collection.id)
+    await api1.disconnect()
+    await api2.disconnect()


### PR DESCRIPTION
## Problem
A non-member **contributor** (e.g. Joshua/AI4Life onboarding to RI-SCALE) whose write access comes from a **collection** configured for contributors — `ai-model-hub` has `"@": ["commit","put_file","edit",...]` — is **denied git push** and forced to use a **workspace-owner token**.

## Root cause (hypha/artifact.py)
In `_get_artifact_with_permission`, the parent-collection permission **fallback was read-only** (`read/list/get_file/...`). Write ops (`commit`/`put_file`/`edit`) checked only the artifact's **own** permissions + a **workspace-level** fallback. So:
- git **clone** works (read falls back to the collection ✅)
- git **push** fails (no write fallback → only a workspace-owner satisfies the workspace-level fallback)

(Separately, `create()` computes `parent_permissions` from the collection but **never persists them** onto the child — a latent inheritance gap. The dynamic fallback below fixes existing artifacts regardless.)

## Fix
Write operations now **fall back to the parent collection's permissions**, mirroring reads. The collection's permission **list is the explicit control surface**:
- `"@": [..,"commit",..]` → contributors push with their **own** token ✅
- `"@": "r"` (read-only) → writes still **denied** (no write op listed) ✅
- **Admin** ops (`delete`/`publish`/`get_secret`/`reset_stats`) deliberately do **NOT** inherit via collection membership.

Note: `UserPermission` is a str-Enum (lexicographic), so admin is excluded **explicitly** (not via `<=`).

## Tests
- `test_collection_contributor_write_inheritance` — non-member writes a collection-child via the `@` grant; delete still denied.
- `test_collection_read_only_denies_contributor_writes` — read-only collection still denies writes.

## Validation
⚠️ Couldn't run the integration suite locally (no Docker/MinIO on this host) — **CI validates**, and the ri-scale agent will run a **before/after Joshua git-push** on dev. **Security-model change — hold for review before prod merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)