### PR TITLE
ci(test): cache fastembed/HF model to survive HuggingFace Hub flakes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,20 @@ jobs:
           key: playwright-${{ hashFiles('requirements.txt') }}
           restore-keys: |
             playwright-
+      - name: Cache fastembed models
+        # Vector-search tests (e.g. test_artifact_vector_collection) download the
+        # ~130MB BAAI/bge-small-en-v1.5 ONNX model from the HuggingFace Hub on first
+        # use. Combined with `pytest -x`, a single unreachable-Hub moment aborts the
+        # whole suite at ~10%. Caching the model like the Playwright browser above
+        # removes the per-run dependency on Hub availability after the first warm-up.
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/fastembed
+            ~/.cache/huggingface
+          key: fastembed-${{ hashFiles('requirements*.txt') }}
+          restore-keys: |
+            fastembed-
       - name: Install conda dependencies
         run: |
           conda install -c conda-forge conda-pack numpy ipykernel pip git-lfs python=${{ matrix.python-version }}


### PR DESCRIPTION
## Problem

`.github/workflows/test.yml` caches pip, `.tox`, and Playwright browsers — but **not** the fastembed / HuggingFace model. Vector-search tests (e.g. `tests/test_artifact.py::test_artifact_vector_collection`) download the ~130MB `BAAI/bge-small-en-v1.5` ONNX model from the HuggingFace Hub on first use on each fresh runner.

Because `tox.ini` runs `pytest -x` (stop-on-first-failure), a **single unreachable-Hub moment** aborts the entire suite at ~10%. This is exactly what killed the 0.21.129 (#1043) matrix run:

```
ValueError: Could not load model BAAI/bge-small-en-v1.5 from any source.
... cannot find the appropriate snapshot folder for the specified revision on the local disk.
Please check your internet connection and try again.
```

`test_mcp_log_level.py` never ran — an unrelated log-hygiene fix was blocked by a transient network flake in a vector test. A plain re-run only helps if the Hub happens to be up.

## Fix

Add a `Cache fastembed models` step mirroring the existing Playwright-browser cache: cache `~/.cache/fastembed` (+ `~/.cache/huggingface` when `HF_HOME` is set), keyed on `hashFiles('requirements*.txt')`. After one warm-up run the model is restored from cache, removing the per-run dependency on Hub availability.

## Scope

- **Workflow-only** — no code, no version bump, benefits every PR.
- The existing `test_artifact.py` `method_timeout=180` covers a **slow** Hub; this covers an **unreachable** one. Complementary, not a replacement.
- Does **not** touch `pytest -x` — that's a separate CI-policy question about failure blast-radius, filed separately for maintainer decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)