### PR TITLE
fix(auth): workspace owner can generate token via read_write token (#958)

### DIFF
--- a/hypha/core/__init__.py
+++ b/hypha/core/__init__.py
@@ -615,6 +615,17 @@ class WorkspaceInfo(BaseModel):
         # check if user_info.id or user_info.email is in the owners list
         if user_info.id in self.owners or user_info.email in self.owners:
             return True
+        # A user always owns their personal workspace ("ws-user-<uid>"), including
+        # when acting through a child token whose own id differs but whose parent
+        # is the user. The parent chain is assigned server-side in generate_token()
+        # (not settable by a caller), so this cannot be forged. This keeps ownership
+        # recognition consistent with how personal workspaces are keyed, regardless
+        # of what is materialised in the owners list.
+        personal_workspaces = {f"ws-user-{user_info.id}"}
+        if user_info.parent:
+            personal_workspaces.add(f"ws-user-{user_info.parent}")
+        if self.id in personal_workspaces:
+            return True
         return False
 
 

--- a/hypha/core/workspace.py
+++ b/hypha/core/workspace.py
@@ -1286,11 +1286,18 @@ class WorkspaceManager:
         allowed_workspace = config.workspace or ws
 
         maximum_permission = user_info.get_permission(allowed_workspace)
-        if not maximum_permission:
+        if maximum_permission != UserPermission.admin:
+            # A workspace owner may always mint tokens for their OWN workspace,
+            # even when the presented token only grants read_write (or nothing).
+            # This ownership fallback previously ran only when the resolved
+            # permission was falsy, so an owner acting through a read_write token
+            # — e.g. a child token scoped to their own workspace — fell through to
+            # "Only admin can generate token" and could not start their own
+            # server-apps. See amun-ai/hypha#958.
             workspace_info = await self.load_workspace_info(allowed_workspace)
-            if workspace_info.owned_by(user_info):
+            if workspace_info is not None and workspace_info.owned_by(user_info):
                 maximum_permission = UserPermission.admin
-            else:
+            elif not maximum_permission:
                 raise PermissionError(
                     f"You do not have any permission for workspace: {allowed_workspace}"
                 )

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -35,6 +35,39 @@ async def test_generate_token(fastapi_server):
     await api1.disconnect()
 
 
+async def test_owner_can_generate_token_with_read_write_token(fastapi_server):
+    """A workspace owner may mint tokens for their own workspace through a
+    read_write token.
+
+    Regression for amun-ai/hypha#958: the owner-elevation fallback in
+    generate_token() previously only ran when the resolved permission was falsy,
+    so an owner acting through a read_write token (e.g. a child token scoped to
+    their own workspace) hit "Only admin can generate token" and could not start
+    their own server-apps.
+    """
+    async with connect_to_server(
+        {"name": "owner app", "server_url": WS_SERVER_URL, "client_id": "owner-app"}
+    ) as api1:
+        workspace = api1.config.workspace
+        # A read_write (non-admin) token for the owner's own workspace.
+        rw_token = await api1.generate_token({"permission": "read_write"})
+
+        async with connect_to_server(
+            {
+                "name": "owner app rw",
+                "server_url": WS_SERVER_URL,
+                "client_id": "owner-app-rw",
+                "token": rw_token,
+                "workspace": workspace,
+            }
+        ) as api2:
+            # The owner (through the read_write child token) must still be able to
+            # mint a token for their own workspace — this raised
+            # "Only admin can generate token" before the fix.
+            child_token = await api2.generate_token({"permission": "read_write"})
+            assert isinstance(child_token, str) and child_token
+
+
 async def test_revoke_token(fastapi_server):
     """Test connecting to the server with a revoked token."""
     async with connect_to_server(


### PR DESCRIPTION
## Summary

Fixes the remaining half of #958. A workspace **owner** cannot generate a token
for **their own workspace** when the token they are acting through only grants
`read_write` — they hit `PermissionError("Only admin can generate token.")`. In
practice this blocks a normal user from starting their own server-app: `apps.start`
calls `workspace.generate_token`, and Svamp's stored/derived token for the user's
own workspace is a child `read_write` token.

#959 (already merged) fixed the *scope-shadowing* half — `get_permission` now
returns the strongest of `*` and the specific-workspace grant. This PR fixes the
*ownership-recognition* half so the two together let an owner start their own
server-apps without an admin token.

## Root cause

`generate_token()` only ran its owner-elevation fallback when the resolved
permission was **falsy**:

```python
maximum_permission = user_info.get_permission(allowed_workspace)
if not maximum_permission:                     # <-- only None triggers the fallback
    workspace_info = await self.load_workspace_info(allowed_workspace)
    if workspace_info.owned_by(user_info):
        maximum_permission = UserPermission.admin
    else:
        raise PermissionError("You do not have any permission ...")
if maximum_permission != UserPermission.admin:
    raise PermissionError("Only admin can generate token.")
```

An owner acting through a `read_write` token has `maximum_permission == read_write`,
skips the fallback entirely, and hits "Only admin can generate token."

There is a second, related gap. A **child token** minted via `generate_token()` gets
a fresh random `id` and carries `parent = <original user id>`, but `owned_by()` only
matched on `id`/`email` being present in the workspace `owners` list. A personal
workspace `ws-user-<uid>` does not necessarily materialise the email in `owners`, so
`owned_by()` returned `False` for the user's own child token even though it is the
same user.

## Changes

1. **`WorkspaceInfo.owned_by()`** also recognises a user's personal workspace by
   construction — `ws-user-<user.id>`, and `ws-user-<user.parent>` for a child token.
   The parent chain is assigned server-side inside `generate_token()` and is not
   settable by a caller, so this cannot be forged. This makes ownership recognition
   consistent with how personal workspaces are keyed, independent of what is
   materialised in `owners`.

2. **`generate_token()`** runs the ownership fallback whenever the resolved
   permission is **below admin** (not only when it is `None`). A non-owner with no
   permission at all still gets the original "no permission" error; a non-owner with
   `read_write` still gets "Only admin can generate token."

## Test

Adds `test_owner_can_generate_token_with_read_write_token`: an owner connects,
mints a `read_write` token, reconnects with it, and mints a further token for their
own workspace — which raised "Only admin can generate token" before this change.

## Notes

This is currently applied in production as a runtime monkeypatch (the amun-ai
platform's `hypha-fix958` launcher, "owner-elevation" patch); merging this lets us
drop that patch. No behavior change for non-owners.
🤖 Generated with [Claude Code](https://claude.com/claude-code)